### PR TITLE
Feature/bulk

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -470,5 +470,6 @@ dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net
 ##########################################
 # Custom - Code Analyzers Rules
 ##########################################
+dotnet_diagnostic.CS1701.severity = none            # Assuming assembly reference matches identity (Mac issue)
 dotnet_diagnostic.CA1014.severity = none            # No need for CLSCompliantAttribute
 dotnet_diagnostic.CA1062.severity = none            # Do not demand null-checking when using nullable reference types.

--- a/src/Atc.Cosmos/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Atc.Cosmos/DependencyInjection/ServiceCollectionExtensions.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ICosmosContainerProvider, CosmosContainerProvider>();
             services.AddSingleton(typeof(ICosmosReader<>), typeof(CosmosReader<>));
             services.AddSingleton(typeof(ICosmosWriter<>), typeof(CosmosWriter<>));
+            services.AddSingleton(typeof(ICosmosBulkWriter<>), typeof(CosmosBulkWriter<>));
             services.AddSingleton<ICosmosInitializer, CosmosInitializer>();
             services.AddSingleton<IJsonCosmosSerializer, JsonCosmosSerializer>();
             services.AddSingleton<ICosmosClientProvider, CosmosClientProvider>();

--- a/src/Atc.Cosmos/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Atc.Cosmos/DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@ using Atc.Cosmos;
 using Atc.Cosmos.DependencyInjection;
 using Atc.Cosmos.Internal;
 using Atc.Cosmos.Serialization;
-using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -60,26 +59,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(typeof(ICosmosWriter<>), typeof(CosmosWriter<>));
             services.AddSingleton<ICosmosInitializer, CosmosInitializer>();
             services.AddSingleton<IJsonCosmosSerializer, JsonCosmosSerializer>();
-
-            services.AddSingleton(s =>
-            {
-                var options = s.GetRequiredService<IOptions<CosmosOptions>>().Value;
-                if (!options.IsValid())
-                {
-                    throw new InvalidOperationException(
-                        $"Invalid configuration in {nameof(CosmosOptions)}.");
-                }
-
-                var connectionString = $"AccountEndpoint={options.AccountEndpoint};AccountKey={options.AccountKey}";
-
-                var clientOptions = s.GetService<IOptions<CosmosClientOptions>>()?.Value
-                    ?? new CosmosClientOptions();
-
-                clientOptions.Serializer = new CosmosSerializerAdapter(
-                    s.GetRequiredService<IJsonCosmosSerializer>());
-
-                return new CosmosClient(connectionString, clientOptions);
-            });
+            services.AddSingleton<ICosmosClientProvider, CosmosClientProvider>();
 
             builder(new CosmosBuilder(services));
             return services;

--- a/src/Atc.Cosmos/ICosmosBulkWriter.cs
+++ b/src/Atc.Cosmos/ICosmosBulkWriter.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Atc.Cosmos
+{
+    /// <summary>
+    /// Represents a writer that can perform bulk operations on Cosmos resources.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of <see cref="ICosmosResource"/>
+    /// to be written by this writer.
+    /// </typeparam>
+    public interface ICosmosBulkWriter<in T>
+        where T : class, ICosmosResource
+    {
+        /// <summary>
+        /// Creates a new resource in Cosmos.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
+        /// will be thrown if a resource already exists.
+        /// </remarks>
+        /// <param name="document">The resource to be created.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task CreateAsync(
+            T document,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Writes a resource in Cosmos, using upsert behavior.
+        /// </summary>
+        /// <param name="document">The resource to be written.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task WriteAsync(
+            T document,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Replaces a resource in Cosmos.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
+        /// will be thrown if the resource does not already exist in Cosmos,
+        /// or if the resource has been updated since it was read
+        /// (using the <see cref="ICosmosResource.ETag"/>).
+        /// </remarks>
+        /// <param name="document">The resource to be created.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task ReplaceAsync(
+            T document,
+            CancellationToken cancellationToken = default);
+
+                /// <summary>
+        /// Deletes the specified <typeparamref name="T"/> resource from Cosmos.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
+        /// will be thrown if resource could not be found.
+        /// </remarks>
+        /// <param name="documentId">Id of the resource.</param>
+        /// <param name="partitionKey">Partition key of the resource.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public Task DeleteAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Atc.Cosmos/Internal/CosmosBulkWriter.cs
+++ b/src/Atc.Cosmos/Internal/CosmosBulkWriter.cs
@@ -1,0 +1,71 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Atc.Cosmos.Serialization;
+using Microsoft.Azure.Cosmos;
+
+namespace Atc.Cosmos.Internal
+{
+    public class CosmosBulkWriter<T> : ICosmosBulkWriter<T>
+        where T : class, ICosmosResource
+    {
+        private readonly Container container;
+        private readonly IJsonCosmosSerializer serializer;
+
+        public CosmosBulkWriter(
+            ICosmosContainerProvider containerProvider,
+            IJsonCosmosSerializer serializer)
+        {
+            this.container = containerProvider.GetContainer<T>(allowBulk: true);
+            this.serializer = serializer;
+        }
+
+        public Task CreateAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+            => container
+                .CreateItemAsync<object>(
+                    document,
+                    new PartitionKey(document.PartitionKey),
+                    new ItemRequestOptions { EnableContentResponseOnWrite = false },
+                    cancellationToken)
+                .GetResourceWithEtag<T>(serializer);
+
+        public Task WriteAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+            => container
+                .UpsertItemAsync<object>(
+                    document,
+                    new PartitionKey(document.PartitionKey),
+                    new ItemRequestOptions { EnableContentResponseOnWrite = false },
+                    cancellationToken)
+                .GetResourceWithEtag<T>(serializer);
+
+        public Task ReplaceAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+            => container
+                .ReplaceItemAsync<object>(
+                    document,
+                    document.DocumentId,
+                    new PartitionKey(document.PartitionKey),
+                    new ItemRequestOptions
+                    {
+                        IfMatchEtag = document.ETag,
+                        EnableContentResponseOnWrite = false,
+                    },
+                    cancellationToken)
+                .GetResourceWithEtag<T>(serializer);
+
+        public Task DeleteAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+            => container
+                .DeleteItemAsync<object>(
+                    documentId,
+                    new PartitionKey(partitionKey),
+                    new ItemRequestOptions { EnableContentResponseOnWrite = false },
+                    cancellationToken: cancellationToken);
+    }
+}

--- a/src/Atc.Cosmos/Internal/CosmosClientProvider.cs
+++ b/src/Atc.Cosmos/Internal/CosmosClientProvider.cs
@@ -1,0 +1,101 @@
+using System;
+using Atc.Cosmos.Serialization;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+
+namespace Atc.Cosmos.Internal
+{
+    public sealed class CosmosClientProvider : IDisposable, ICosmosClientProvider
+    {
+        private readonly IOptions<CosmosOptions> cosmosOptions;
+        private readonly IOptions<CosmosClientOptions> cosmosClientOptions;
+        private readonly IJsonCosmosSerializer serializer;
+        private CosmosClient? client;
+        private CosmosClient? bulkClient;
+
+        public CosmosClientProvider(
+            IOptions<CosmosOptions> cosmosOptions,
+            IOptions<CosmosClientOptions> cosmosClientOptions,
+            IJsonCosmosSerializer serializer)
+        {
+            this.cosmosOptions = cosmosOptions;
+            this.cosmosClientOptions = cosmosClientOptions;
+            this.serializer = serializer;
+
+            var options = cosmosOptions.Value;
+            if (!IsValid(options))
+            {
+                throw new InvalidOperationException(
+                    $"Invalid configuration in {nameof(CosmosOptions)}.");
+            }
+        }
+
+        public CosmosClient GetClient()
+            => client ??= CreateClient(allowBulk: false);
+
+        public CosmosClient GetBulkClient()
+            => bulkClient ??= CreateClient(allowBulk: true);
+
+        public void Dispose()
+        {
+            client?.Dispose();
+            bulkClient?.Dispose();
+        }
+
+        private static bool IsValid(CosmosOptions? options)
+            => options is not null
+            && !string.IsNullOrEmpty(options.AccountEndpoint)
+            && !string.IsNullOrEmpty(options.AccountKey)
+            && !string.IsNullOrEmpty(options.DatabaseName);
+
+        private CosmosClient CreateClient(bool allowBulk)
+        {
+            var connectionString =
+                $"AccountEndpoint={cosmosOptions.Value.AccountEndpoint};" +
+                $"AccountKey={cosmosOptions.Value.AccountKey}";
+
+            var options = CreateCosmosClientOptions();
+            options.AllowBulkExecution = allowBulk;
+            options.Serializer = cosmosClientOptions.Value.Serializer
+                ?? new CosmosSerializerAdapter(serializer);
+
+            return new CosmosClient(connectionString, options);
+        }
+
+        private CosmosClientOptions CreateCosmosClientOptions()
+        {
+            var result = new CosmosClientOptions();
+
+            if (cosmosClientOptions is { Value: { } o })
+            {
+                result.ApplicationName = o.ApplicationName;
+                result.ApplicationPreferredRegions = o.ApplicationPreferredRegions;
+                result.ApplicationRegion = o.ApplicationRegion;
+                result.ConnectionMode = o.ConnectionMode;
+                result.ConsistencyLevel = o.ConsistencyLevel;
+
+                foreach (var handler in o.CustomHandlers)
+                {
+                    result.CustomHandlers.Add(handler);
+                }
+
+                result.HttpClientFactory = o.HttpClientFactory;
+                result.IdleTcpConnectionTimeout = o.IdleTcpConnectionTimeout;
+                result.LimitToEndpoint = o.LimitToEndpoint;
+                result.MaxRequestsPerTcpConnection = o.MaxRequestsPerTcpConnection;
+                result.MaxRetryWaitTimeOnRateLimitedRequests = o.MaxRetryWaitTimeOnRateLimitedRequests;
+                result.MaxTcpConnectionsPerEndpoint = o.MaxTcpConnectionsPerEndpoint;
+                result.OpenTcpConnectionTimeout = o.OpenTcpConnectionTimeout;
+                result.PortReuseMode = o.PortReuseMode;
+                result.RequestTimeout = o.RequestTimeout;
+                result.SerializerOptions = o.SerializerOptions;
+                result.WebProxy = o.WebProxy;
+                result.EnableTcpConnectionEndpointRediscovery = o.EnableTcpConnectionEndpointRediscovery;
+                result.GatewayModeMaxConnectionLimit = o.GatewayModeMaxConnectionLimit;
+                result.MaxRetryAttemptsOnRateLimitedRequests = o.MaxRetryAttemptsOnRateLimitedRequests;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Atc.Cosmos/Internal/CosmosWriter.cs
+++ b/src/Atc.Cosmos/Internal/CosmosWriter.cs
@@ -20,7 +20,8 @@ namespace Atc.Cosmos.Internal
             ICosmosReader<T> reader,
             IJsonCosmosSerializer serializer)
         {
-            this.container = containerProvider.GetContainer<T>();
+            this.container = containerProvider
+                .GetContainer<T>(allowBulk: false);
             this.reader = reader;
             this.serializer = serializer;
         }

--- a/src/Atc.Cosmos/Internal/ICosmosClientProvider.cs
+++ b/src/Atc.Cosmos/Internal/ICosmosClientProvider.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Azure.Cosmos;
+
+namespace Atc.Cosmos.Internal
+{
+    public interface ICosmosClientProvider
+    {
+        CosmosClient GetClient();
+
+        CosmosClient GetBulkClient();
+    }
+}

--- a/src/Atc.Cosmos/Internal/ICosmosContainerProvider.cs
+++ b/src/Atc.Cosmos/Internal/ICosmosContainerProvider.cs
@@ -7,6 +7,6 @@ namespace Atc.Cosmos.Internal
     /// </summary>
     public interface ICosmosContainerProvider
     {
-        Container GetContainer<T>();
+        Container GetContainer<T>(bool allowBulk = false);
     }
 }

--- a/test/Atc.Cosmos.Tests/CosmosBulkWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosBulkWriterTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Atc.Cosmos.Internal;
+using Atc.Cosmos.Serialization;
+using Atc.Test;
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using NSubstitute;
+using Xunit;
+
+namespace Atc.Cosmos.Tests
+{
+    public class CosmosBulkWriterTests
+    {
+        private readonly Record record;
+        private readonly Container container;
+        private readonly ICosmosContainerProvider containerProvider;
+        private readonly IJsonCosmosSerializer serializer;
+        private readonly CosmosBulkWriter<Record> sut;
+
+        public CosmosBulkWriterTests()
+        {
+            record = new Fixture().Create<Record>();
+
+            container = Substitute.For<Container>();
+
+            containerProvider = Substitute.For<ICosmosContainerProvider>();
+            containerProvider
+                .GetContainer<Record>()
+                .ReturnsForAnyArgs(container, null);
+
+            var response = Substitute.For<ItemResponse<object>>();
+            response.Resource.Returns(new Fixture().Create<string>());
+            container
+                .CreateItemAsync<object>(default, default, default, default)
+                .ReturnsForAnyArgs(response);
+            container
+                .ReplaceItemAsync<object>(default, default, default, default, default)
+                .ReturnsForAnyArgs(response);
+            container
+                .UpsertItemAsync<object>(default, default, default, default)
+                .ReturnsForAnyArgs(response);
+
+            serializer = Substitute.For<IJsonCosmosSerializer>();
+            serializer
+                .FromString<Record>(default)
+                .ReturnsForAnyArgs(new Fixture().Create<Record>());
+
+            sut = new CosmosBulkWriter<Record>(containerProvider, serializer);
+        }
+
+        [Fact]
+        public void Implements_Interface()
+            => sut.Should().BeAssignableTo<ICosmosBulkWriter<Record>>();
+
+        [Theory, AutoNSubstituteData]
+        public async Task WriteAsync_Uses_The_Right_Container(
+            CancellationToken cancellationToken)
+        {
+            await sut.WriteAsync(record, cancellationToken);
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>(
+                    allowBulk: true);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task WriteAsync_UpsertItem_In_Container(
+            CancellationToken cancellationToken)
+        {
+            containerProvider
+                .GetContainer<Record>()
+                .ReturnsForAnyArgs(container);
+
+            await sut.WriteAsync(record, cancellationToken);
+            await container
+                .Received(1)
+                .UpsertItemAsync<object>(
+                    record,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.EnableContentResponseOnWrite == false),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CreateAsync_Calls_CreateItem_On_Container(
+           CancellationToken cancellationToken)
+        {
+            await sut.CreateAsync(record, cancellationToken);
+            _ = container
+                .Received(1)
+                .CreateItemAsync<object>(
+                    record,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.EnableContentResponseOnWrite == false),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReplaceAsync_Calls_ReplaceItemAsync_On_Container(
+           CancellationToken cancellationToken)
+        {
+            await sut.ReplaceAsync(record, cancellationToken);
+            _ = container
+                .Received(1)
+                .ReplaceItemAsync<object>(
+                    record,
+                    record.Id,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(o =>
+                        o.EnableContentResponseOnWrite == false &&
+                        o.IfMatchEtag == ((ICosmosResource)record).ETag),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Multiple_Operations_Uses_Same_Container(
+            CancellationToken cancellationToken)
+        {
+            _ = sut.WriteAsync(record, cancellationToken);
+            _ = sut.WriteAsync(record, cancellationToken);
+            _ = sut.CreateAsync(record, cancellationToken);
+            _ = sut.CreateAsync(record, cancellationToken);
+            _ = sut.ReplaceAsync(record, cancellationToken);
+            _ = sut.ReplaceAsync(record, cancellationToken);
+
+            container
+                .ReceivedCalls()
+                .Should()
+                .HaveCount(6);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task DeleteAsync_Calls_DeleteItemAsync_On_Container(
+           CancellationToken cancellationToken)
+        {
+            await sut.DeleteAsync(record.Id, record.Pk, cancellationToken);
+            _ = container
+                .Received(1)
+                .DeleteItemAsync<object>(
+                    record.Id,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.EnableContentResponseOnWrite == false),
+                    cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/test/Atc.Cosmos.Tests/CosmosWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosWriterTests.cs
@@ -31,7 +31,7 @@ namespace Atc.Cosmos.Tests
             containerProvider = Substitute.For<ICosmosContainerProvider>();
             containerProvider
                 .GetContainer<Record>()
-                .Returns(container, null);
+                .ReturnsForAnyArgs(container, null);
 
             var response = Substitute.For<ItemResponse<object>>();
             response.Resource.Returns(new Fixture().Create<string>());
@@ -69,14 +69,17 @@ namespace Atc.Cosmos.Tests
             await sut.WriteAsync(record, cancellationToken);
             containerProvider
                 .Received(1)
-                .GetContainer<Record>();
+                .GetContainer<Record>(
+                    allowBulk: false);
         }
 
         [Theory, AutoNSubstituteData]
         public async Task WriteAsync_UpsertItem_In_Container(
             CancellationToken cancellationToken)
         {
-            containerProvider.GetContainer<Record>().Returns(container);
+            containerProvider
+                .GetContainer<Record>()
+                .ReturnsForAnyArgs(container);
 
             await sut.WriteAsync(record, cancellationToken);
             await container
@@ -144,6 +147,7 @@ namespace Atc.Cosmos.Tests
                 .DeleteItemAsync<object>(
                     record.Id,
                     new PartitionKey(record.Pk),
+                    Arg.Any<ItemRequestOptions>(),
                     cancellationToken: cancellationToken);
         }
 

--- a/test/Atc.Cosmos.Tests/Internal/CosmosClientProviderTests.cs
+++ b/test/Atc.Cosmos.Tests/Internal/CosmosClientProviderTests.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Atc.Cosmos.Internal;
+using Atc.Cosmos.Serialization;
+using Atc.Test;
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Atc.Cosmos.Tests.Internal
+{
+    public sealed class CosmosClientProviderTests : IDisposable
+    {
+        private readonly CosmosOptions cosmosOptions;
+        private readonly CosmosClientOptions cosmosClientOptions;
+        private readonly IJsonCosmosSerializer serializer;
+        private readonly CosmosClientProvider sut;
+
+        public CosmosClientProviderTests()
+        {
+            var fixture = FixtureFactory.Create();
+            cosmosOptions = new CosmosOptions
+            {
+                AccountEndpoint = fixture.Create<Uri>().AbsoluteUri,
+                AccountKey = Convert.ToBase64String(Encoding.UTF8.GetBytes(fixture.Create<string>())),
+                DatabaseName = fixture.Create<string>(),
+                DatabaseThroughput = fixture.Create<int>(),
+            };
+
+            cosmosClientOptions = new CosmosClientOptions
+            {
+                ApplicationName = fixture.Create<string>(),
+            };
+
+            serializer = Substitute.For<IJsonCosmosSerializer>();
+
+            sut = new CosmosClientProvider(
+                Options.Create(cosmosOptions),
+                Options.Create(cosmosClientOptions),
+                serializer);
+        }
+
+        public void Dispose()
+            => sut.Dispose();
+
+        [Fact]
+        public void Clients_Should_Use_Endpoint_From_CosmosOptions()
+            => sut
+                .GetClient()
+                .Endpoint
+                .Should()
+                .BeEquivalentTo(
+                    new Uri(cosmosOptions.AccountEndpoint));
+
+        [Fact]
+        public void Client_Should_Use_CosmosClientOptions()
+            => sut
+                .GetClient()
+                .ClientOptions
+                .Should()
+                .BeEquivalentTo(
+                    cosmosClientOptions,
+                    o => o
+                        .Excluding(o => o.AllowBulkExecution)
+                        .Excluding(o => o.Serializer));
+
+        [Fact]
+        public void Client_Should_Use_Default_Serializer_If_None_Specified()
+        {
+            cosmosClientOptions.Serializer = null;
+
+            var actualSerializer = sut
+                .GetClient()
+                .ClientOptions
+                .Serializer;
+
+            actualSerializer
+                .Should()
+                .BeAssignableTo<CosmosSerializerAdapter>();
+
+            ((CosmosSerializerAdapter)actualSerializer)
+               .Serializer
+               .Should()
+               .Be(serializer);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Client_Should_Use_CustomSerializer_If_Specified(
+            [Substitute] CosmosSerializer serializer)
+        {
+            cosmosClientOptions.Serializer = serializer;
+            sut
+                .GetClient()
+                .ClientOptions
+                .Serializer
+                .Should()
+                .Be(serializer);
+        }
+
+        [Fact]
+        public void GetClient_Should_Return_Same_Instance()
+            => sut
+                .GetClient()
+                .Should()
+                .Be(sut.GetClient());
+
+        [Fact]
+        public void GetClient_And_GetBulkClinet_Should_Return_Different_Instances()
+            => sut
+                .GetClient()
+                .Should()
+                .NotBe(sut.GetBulkClient());
+
+        [Fact]
+        public void GetBulkClient_Should_Return_Same_Instance()
+            => sut
+                .GetBulkClient()
+                .Should()
+                .Be(sut.GetBulkClient());
+
+        [Fact]
+        public void BulkClient_Should_Use_Endpoint_From_CosmosOptions()
+            => sut
+                .GetBulkClient()
+                .Endpoint
+                .Should()
+                .BeEquivalentTo(
+                    new Uri(cosmosOptions.AccountEndpoint));
+
+        [Fact]
+        public void BulkClient_Should_Use_CosmosClientOptions()
+            => sut
+                .GetBulkClient()
+                .ClientOptions
+                .Should()
+                .BeEquivalentTo(
+                    cosmosClientOptions,
+                    o => o
+                        .Excluding(o => o.AllowBulkExecution)
+                        .Excluding(o => o.Serializer));
+
+        [Fact]
+        public void BulkClient_Should_Use_Default_Serializer_If_None_Specified()
+        {
+            cosmosClientOptions.Serializer = null;
+
+            var actualSerializer = sut
+                .GetBulkClient()
+                .ClientOptions
+                .Serializer;
+
+            actualSerializer
+                .Should()
+                .BeAssignableTo<CosmosSerializerAdapter>();
+
+            ((CosmosSerializerAdapter)actualSerializer)
+               .Serializer
+               .Should()
+               .Be(serializer);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void BulkClient_Should_Use_CustomSerializer_If_Specified(
+            [Substitute] CosmosSerializer serializer)
+        {
+            cosmosClientOptions.Serializer = serializer;
+            sut
+                .GetBulkClient()
+                .ClientOptions
+                .Serializer
+                .Should()
+                .Be(serializer);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a `ICosmosBulkWriter<T>` that is optimized for performing bulk operations by:
* Using a `CosmosClient` with the `AllowBulkExecution` set to `true` (this option is recommended for non-latency sensitive scenarios only)
* Setting `EnableContentResponseOnWrite` on Cosmos calls, to reduce the networking and CPU load by not sending the resource back over the network

Bulk operations are performed by running tasks in parallel like so:
```csharp
private ICosmosBulkWriter<Resource> bulkWriter;

public async Task WriteAllAsync(Resource[] resources)
    => Task.WhenAll(
        resources
            .Select(r => bulkWriter.WriteAsync(r))
            .ToArray());
```

Changes include:
* Introduce CosmosClientProvider
* Add support using bulk enabled client in CosmosContainerProvider
* Replace CosmosClient setup with CosmosClientProvider logic
* Introduce CosmosBulkWriter
* Ignore CS1701 warnings