### PR TITLE
Feature/fakes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -473,3 +473,4 @@ dotnet_diagnostic.S1135.severity = suggestion       # https://github.com/atc-net
 dotnet_diagnostic.CS1701.severity = none            # Assuming assembly reference matches identity (Mac issue)
 dotnet_diagnostic.CA1014.severity = none            # No need for CLSCompliantAttribute
 dotnet_diagnostic.CA1062.severity = none            # Do not demand null-checking when using nullable reference types.
+dotnet_diagnostic.MA0006.severity = none            # Use String.Equals instead of equality operator

--- a/src/Atc.Cosmos/ICosmosBulkReader.cs
+++ b/src/Atc.Cosmos/ICosmosBulkReader.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
@@ -33,7 +34,8 @@ namespace Atc.Cosmos
         /// Cosmos collection.
         /// </summary>
         /// <remarks>
-        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.NotFound"/>
         /// will be thrown if resource could not be found.
         /// </remarks>
         /// <param name="documentId">Id of the resource.</param>
@@ -49,10 +51,6 @@ namespace Atc.Cosmos
         /// Reads all the specified <typeparamref name="T"/> resource from the configured
         /// Cosmos collection.
         /// </summary>
-        /// <remarks>
-        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
-        /// will be thrown if resource could not be found.
-        /// </remarks>
         /// <param name="partitionKey">Partition key of the resource.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
         /// <returns>A <see cref="Task"/> the requested <typeparamref name="T"/> resource.</returns>
@@ -66,7 +64,7 @@ namespace Atc.Cosmos
         /// <param name="query">Cosmos query to execute.</param>
         /// <param name="partitionKey">Partition key of the resource.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
-        /// <returns>An <see cref="System.Collections.Generic.IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="T"/> resources.</returns>
+        /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="T"/> resources.</returns>
         public IAsyncEnumerable<T> QueryAsync(
             QueryDefinition query,
             string partitionKey,

--- a/src/Atc.Cosmos/ICosmosBulkWriter.cs
+++ b/src/Atc.Cosmos/ICosmosBulkWriter.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
 
 namespace Atc.Cosmos
 {
@@ -15,10 +16,11 @@ namespace Atc.Cosmos
         where T : class, ICosmosResource
     {
         /// <summary>
-        /// Creates a new resource in Cosmos.
+        /// Creates a new <typeparamref name="T"/> resource in Cosmos.
         /// </summary>
         /// <remarks>
-        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.Conflict"/>
         /// will be thrown if a resource already exists.
         /// </remarks>
         /// <param name="document">The resource to be created.</param>
@@ -29,7 +31,7 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Writes a resource in Cosmos, using upsert behavior.
+        /// Writes a <typeparamref name="T"/> resource to Cosmos, using upsert behavior.
         /// </summary>
         /// <param name="document">The resource to be written.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
@@ -39,13 +41,20 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Replaces a resource in Cosmos.
+        /// Replaces a <typeparamref name="T"/> resource in Cosmos.
         /// </summary>
         /// <remarks>
-        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
-        /// will be thrown if the resource does not already exist in Cosmos,
-        /// or if the resource has been updated since it was read
-        /// (using the <see cref="ICosmosResource.ETag"/>).
+        /// <para>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.NotFound"/>
+        /// will be thrown if the resource does not already exist in Cosmos.
+        /// </para>
+        /// <para>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.PreconditionFailed"/>
+        /// will be thrown if the resource has been updated since it was read
+        /// (using the <see cref="ICosmosResource.ETag"/> to match the version).
+        /// </para>
         /// </remarks>
         /// <param name="document">The resource to be created.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
@@ -58,8 +67,10 @@ namespace Atc.Cosmos
         /// Deletes the specified <typeparamref name="T"/> resource from Cosmos.
         /// </summary>
         /// <remarks>
-        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
-        /// will be thrown if resource could not be found.
+        /// A <see cref="CosmosException"/>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.NotFound"/>
+        /// will be thrown if the resource does not already exist in Cosmos.
         /// </remarks>
         /// <param name="documentId">Id of the resource.</param>
         /// <param name="partitionKey">Partition key of the resource.</param>

--- a/src/Atc.Cosmos/ICosmosReader.cs
+++ b/src/Atc.Cosmos/ICosmosReader.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
@@ -33,7 +34,8 @@ namespace Atc.Cosmos
         /// Cosmos collection.
         /// </summary>
         /// <remarks>
-        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.NotFound"/>
         /// will be thrown if resource could not be found.
         /// </remarks>
         /// <param name="documentId">Id of the resource.</param>
@@ -49,10 +51,6 @@ namespace Atc.Cosmos
         /// Reads all the specified <typeparamref name="T"/> resource from the configured
         /// Cosmos collection.
         /// </summary>
-        /// <remarks>
-        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
-        /// will be thrown if resource could not be found.
-        /// </remarks>
         /// <param name="partitionKey">Partition key of the resource.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
         /// <returns>A <see cref="Task"/> the requested <typeparamref name="T"/> resource.</returns>
@@ -66,7 +64,7 @@ namespace Atc.Cosmos
         /// <param name="query">Cosmos query to execute.</param>
         /// <param name="partitionKey">Partition key of the resource.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
-        /// <returns>An <see cref="System.Collections.Generic.IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="T"/> resources.</returns>
+        /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="T"/> resources.</returns>
         public IAsyncEnumerable<T> QueryAsync(
             QueryDefinition query,
             string partitionKey,

--- a/src/Atc.Cosmos/ICosmosWriter.cs
+++ b/src/Atc.Cosmos/ICosmosWriter.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
 
 namespace Atc.Cosmos
 {
@@ -18,7 +20,8 @@ namespace Atc.Cosmos
         /// Creates a new <typeparamref name="T"/> resource in Cosmos.
         /// </summary>
         /// <remarks>
-        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.Conflict"/>
         /// will be thrown if a resource already exists.
         /// </remarks>
         /// <param name="document">The resource to be created.</param>
@@ -42,10 +45,17 @@ namespace Atc.Cosmos
         /// Replaces a <typeparamref name="T"/> resource in Cosmos.
         /// </summary>
         /// <remarks>
-        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
-        /// will be thrown if the resource does not already exist in Cosmos,
-        /// or if the resource has been updated since it was read
-        /// (using the <see cref="ICosmosResource.ETag"/>).
+        /// <para>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.NotFound"/>
+        /// will be thrown if the resource does not already exist in Cosmos.
+        /// </para>
+        /// <para>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.PreconditionFailed"/>
+        /// will be thrown if the resource has been updated since it was read
+        /// (using the <see cref="ICosmosResource.ETag"/> to match the version).
+        /// </para>
         /// </remarks>
         /// <param name="document">The resource to be created.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
@@ -58,8 +68,10 @@ namespace Atc.Cosmos
         /// Deletes the specified <typeparamref name="T"/> resource from Cosmos.
         /// </summary>
         /// <remarks>
-        /// A <see cref="Microsoft.Azure.Cosmos.CosmosException"/>
-        /// will be thrown if resource could not be found.
+        /// A <see cref="CosmosException"/>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.NotFound"/>
+        /// will be thrown if the resource does not already exist in Cosmos.
         /// </remarks>
         /// <param name="documentId">Id of the resource.</param>
         /// <param name="partitionKey">Partition key of the resource.</param>
@@ -74,6 +86,19 @@ namespace Atc.Cosmos
         /// Updates a <typeparamref name="T"/> resource that is read from the configured
         /// Cosmos collection.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.NotFound"/>
+        /// will be thrown if the resource does not already exist in Cosmos.
+        /// </para>
+        /// <para>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.PreconditionFailed"/>
+        /// will be thrown if the resource is being updated simultanious by another thread
+        /// and the <paramref name="retries"/> has run out.
+        /// </para>
+        /// </remarks>
         /// <param name="documentId">Id of the resource.</param>
         /// <param name="partitionKey">Partition key of the resource.</param>
         /// <param name="updateDocument">Function for applying updates to the resource.</param>
@@ -91,6 +116,19 @@ namespace Atc.Cosmos
         /// Updates a <typeparamref name="T"/> resource that is read from the configured
         /// Cosmos collection.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.NotFound"/>
+        /// will be thrown if the resource does not already exist in Cosmos.
+        /// </para>
+        /// <para>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.PreconditionFailed"/>
+        /// will be thrown if the resource is being updated simultanious by another thread
+        /// and the <paramref name="retries"/> has run out.
+        /// </para>
+        /// </remarks>
         /// <param name="documentId">Id of the resource.</param>
         /// <param name="partitionKey">Partition key of the resource.</param>
         /// <param name="updateDocument">Function for applying updates to the resource.</param>
@@ -108,6 +146,12 @@ namespace Atc.Cosmos
         /// Updates a <typeparamref name="T"/> resource that is read from the configured
         /// Cosmos collection, or creates it if it does not exist.
         /// </summary>
+        /// <remarks>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.PreconditionFailed"/>
+        /// will be thrown if the resource is being updated simultanious by another thread
+        /// and the <paramref name="retries"/> has run out.
+        /// </remarks>
         /// <param name="getDefaultDocument">Function for creating the default resource. The returned resource need to have the DocumentId and PartitionKey set.</param>
         /// <param name="updateDocument">Function for applying updates to the resource.</param>
         /// <param name="retries">Number of retries when a conflict occurs.</param>
@@ -123,6 +167,12 @@ namespace Atc.Cosmos
         /// Updates a <typeparamref name="T"/> resource that is read from the configured
         /// Cosmos collection, or creates it if it does not exist.
         /// </summary>
+        /// <remarks>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.PreconditionFailed"/>
+        /// will be thrown if the resource is being updated simultanious by another thread
+        /// and the <paramref name="retries"/> has run out.
+        /// </remarks>
         /// <param name="getDefaultDocument">Function for creating the default resource. The returned resource need to have the DocumentId and PartitionKey set.</param>
         /// <param name="updateDocument">Function for applying updates to the resource.</param>
         /// <param name="retries">Number of retries when a conflict occurs.</param>

--- a/src/Atc.Cosmos/Testing/FakeCosmos.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmos.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+
+namespace Atc.Cosmos.Testing
+{
+    [SuppressMessage(
+       "Design",
+       "MA0016:Prefer return collection abstraction instead of implementation",
+       Justification = "By design")]
+    [SuppressMessage(
+       "Design",
+       "CA1002:Do not expose generic lists",
+       Justification = "By design")]
+    [SuppressMessage(
+       "Usage",
+       "CA2227:Collection properties should be read only",
+       Justification = "By design")]
+    public sealed class FakeCosmos<T> :
+        ICosmosReader<T>,
+        ICosmosWriter<T>,
+        ICosmosBulkReader<T>,
+        ICosmosBulkWriter<T>
+        where T : class, ICosmosResource
+    {
+        public FakeCosmos()
+            : this(
+                  new FakeCosmosReader<T>(),
+                  new FakeCosmosWriter<T>())
+        {
+        }
+
+        public FakeCosmos(
+            FakeCosmosReader<T> reader,
+            FakeCosmosWriter<T> writer)
+        {
+            Reader = reader;
+            Writer = writer;
+            writer.Documents = reader.Documents;
+        }
+
+        public List<T> Documents
+        {
+            get => Reader.Documents;
+            set
+            {
+                Reader.Documents = value;
+                Writer.Documents = value;
+            }
+        }
+
+        public List<object> QueryResults
+        {
+            get => Reader.QueryResults;
+            set
+            {
+                Reader.QueryResults = value;
+            }
+        }
+
+        public FakeCosmosReader<T> Reader { get; }
+
+        public FakeCosmosWriter<T> Writer { get; }
+
+        Task<T?> ICosmosReader<T>.FindAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosReader<T>)Reader)
+                .FindAsync(
+                    documentId,
+                    partitionKey,
+                    cancellationToken);
+
+        Task<T> ICosmosReader<T>.ReadAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosReader<T>)Reader)
+                .ReadAsync(
+                    documentId,
+                    partitionKey,
+                    cancellationToken);
+
+        IAsyncEnumerable<T> ICosmosReader<T>.ReadAllAsync(
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosReader<T>)Reader)
+                .ReadAllAsync(
+                    partitionKey,
+                    cancellationToken);
+
+        IAsyncEnumerable<T> ICosmosReader<T>.QueryAsync(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosReader<T>)Reader)
+                .QueryAsync(
+                    query,
+                    partitionKey,
+                    cancellationToken);
+
+        IAsyncEnumerable<TResult> ICosmosReader<T>.QueryAsync<TResult>(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosReader<T>)Reader)
+                .QueryAsync<TResult>(
+                    query,
+                    partitionKey,
+                    cancellationToken);
+
+        Task<T?> ICosmosBulkReader<T>.FindAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosBulkReader<T>)Reader)
+                .FindAsync(
+                    documentId,
+                    partitionKey,
+                    cancellationToken);
+
+        Task<T> ICosmosBulkReader<T>.ReadAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosBulkReader<T>)Reader)
+                .ReadAsync(
+                    documentId,
+                    partitionKey,
+                    cancellationToken);
+
+        IAsyncEnumerable<T> ICosmosBulkReader<T>.ReadAllAsync(
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosBulkReader<T>)Reader)
+                .ReadAllAsync(
+                    partitionKey,
+                    cancellationToken);
+
+        IAsyncEnumerable<T> ICosmosBulkReader<T>.QueryAsync(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosBulkReader<T>)Reader)
+                .QueryAsync(
+                    query,
+                    partitionKey,
+                    cancellationToken);
+
+        IAsyncEnumerable<TResult> ICosmosBulkReader<T>.QueryAsync<TResult>(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosBulkReader<T>)Reader)
+                .QueryAsync<TResult>(
+                    query,
+                    partitionKey,
+                    cancellationToken);
+
+        Task<T> ICosmosWriter<T>.CreateAsync(
+            T document,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .CreateAsync(
+                    document,
+                    cancellationToken);
+
+        Task<T> ICosmosWriter<T>.WriteAsync(
+            T document,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .WriteAsync(
+                    document,
+                    cancellationToken);
+
+        Task<T> ICosmosWriter<T>.ReplaceAsync(
+            T document,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .ReplaceAsync(
+                    document,
+                    cancellationToken);
+
+        Task ICosmosWriter<T>.DeleteAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .DeleteAsync(
+                    documentId,
+                    partitionKey,
+                    cancellationToken);
+
+        Task<T> ICosmosWriter<T>.UpdateAsync(
+            string documentId,
+            string partitionKey,
+            Func<T, Task> updateDocument,
+            int retries,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .UpdateAsync(
+                    documentId,
+                    partitionKey,
+                    updateDocument,
+                    retries,
+                    cancellationToken);
+
+        Task<T> ICosmosWriter<T>.UpdateAsync(
+            string documentId,
+            string partitionKey,
+            Action<T> updateDocument,
+            int retries,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .UpdateAsync(
+                    documentId,
+                    partitionKey,
+                    updateDocument,
+                    retries,
+                    cancellationToken);
+
+        Task<T> ICosmosWriter<T>.UpdateOrCreateAsync(
+            Func<T> getDefaultDocument,
+            Func<T, Task> updateDocument,
+            int retries,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .UpdateOrCreateAsync(
+                    getDefaultDocument,
+                    updateDocument,
+                    retries,
+                    cancellationToken);
+
+        Task<T> ICosmosWriter<T>.UpdateOrCreateAsync(
+            Func<T> getDefaultDocument,
+            Action<T> updateDocument,
+            int retries,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .UpdateOrCreateAsync(
+                    getDefaultDocument,
+                    updateDocument,
+                    retries,
+                    cancellationToken);
+
+        Task ICosmosBulkWriter<T>.CreateAsync(
+             T document,
+             CancellationToken cancellationToken)
+             => ((ICosmosBulkWriter<T>)Writer)
+                 .CreateAsync(
+                     document,
+                     cancellationToken);
+
+        Task ICosmosBulkWriter<T>.WriteAsync(
+            T document,
+            CancellationToken cancellationToken)
+            => ((ICosmosBulkWriter<T>)Writer)
+                .WriteAsync(
+                    document,
+                    cancellationToken);
+
+        Task ICosmosBulkWriter<T>.ReplaceAsync(
+            T document,
+            CancellationToken cancellationToken)
+            => ((ICosmosBulkWriter<T>)Writer)
+                .ReplaceAsync(
+                    document,
+                    cancellationToken);
+
+        Task ICosmosBulkWriter<T>.DeleteAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosBulkWriter<T>)Writer)
+                .DeleteAsync(
+                    documentId,
+                    partitionKey,
+                    cancellationToken);
+    }
+}

--- a/src/Atc.Cosmos/Testing/FakeCosmosReader.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmosReader.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+
+namespace Atc.Cosmos.Testing
+{
+    /// <summary>
+    /// Represents a fake <see cref="ICosmosReader{T}"/>
+    /// that can be used when unit testing client code.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of <see cref="ICosmosResource"/>
+    /// to be read by this reader.
+    /// </typeparam>
+    public class FakeCosmosReader<T> : ICosmosReader<T>
+        where T : class, ICosmosResource
+    {
+        /// <summary>
+        /// Gets or sets the list of documents to return by the fake reader.
+        /// </summary>
+        [SuppressMessage(
+            "Design",
+            "MA0016:Prefer return collection abstraction instead of implementation",
+            Justification = "By design")]
+        public List<T> Documents { get; set; }
+            = new List<T>();
+
+        /// <summary>
+        /// Gets or sets the list of custom results to be returned by the
+        /// <see cref="QueryAsync{TResult}(QueryDefinition, string, CancellationToken)"/> method.
+        /// </summary>
+        [SuppressMessage(
+            "Design",
+            "MA0016:Prefer return collection abstraction instead of implementation",
+            Justification = "By design")]
+        public List<object> QueryResults { get; set; }
+            = new List<object>();
+
+        public Task<T?> FindAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(
+                Documents.Find(d
+                    => d.DocumentId == documentId
+                    && d.PartitionKey == partitionKey));
+
+        public Task<T> ReadAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+        {
+            var item = Documents.Find(d
+               => d.DocumentId == documentId
+               && d.PartitionKey == partitionKey);
+
+            if (item is null)
+            {
+                throw new CosmosException(
+                    $"Document not found. " +
+                    $"Id: {documentId}. " +
+                    $"PartitionKey: {partitionKey}",
+                    HttpStatusCode.NotFound,
+                    0,
+                    string.Empty,
+                    0);
+            }
+
+            return Task.FromResult(item);
+        }
+
+        public IAsyncEnumerable<T> ReadAllAsync(
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+            => GetAsyncEnumerator(
+                Documents.Where(d => d.PartitionKey == partitionKey));
+
+        public IAsyncEnumerable<T> QueryAsync(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+            => GetAsyncEnumerator(
+                Documents.Where(d => d.PartitionKey == partitionKey));
+
+        public IAsyncEnumerable<TResult> QueryAsync<TResult>(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+            => GetAsyncEnumerator(
+                QueryResults.OfType<TResult>());
+
+        private static async IAsyncEnumerable<TItem> GetAsyncEnumerator<TItem>(
+            IEnumerable<TItem> items)
+        {
+            foreach (var item in items)
+            {
+                yield return await Task
+                    .FromResult(item)
+                    .ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Atc.Cosmos/Testing/FakeCosmosWriter.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmosWriter.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos;
+
+namespace Atc.Cosmos.Testing
+{
+    public class FakeCosmosWriter<T> : ICosmosWriter<T>
+        where T : class, ICosmosResource
+    {
+        /// <summary>
+        /// Gets or sets the list of documents to be modified by the fake writer.
+        /// </summary>
+        [SuppressMessage(
+            "Design",
+            "MA0016:Prefer return collection abstraction instead of implementation",
+            Justification = "By design")]
+        public List<T> Documents { get; set; }
+            = new List<T>();
+
+        public virtual Task<T> CreateAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+        {
+            GuardNotExists(document);
+
+            document.ETag = Guid.NewGuid().ToString();
+            Documents.Add(document);
+            return Task.FromResult(document);
+        }
+
+        public Task<T> WriteAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+        {
+            Documents.RemoveAll(d
+                => d.DocumentId == document.DocumentId
+                && d.PartitionKey == document.PartitionKey);
+
+            document.ETag = Guid.NewGuid().ToString();
+            Documents.Add(document);
+
+            return Task.FromResult(document);
+        }
+
+        public virtual Task<T> ReplaceAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+        {
+            GuardExistsWithEtag(document);
+
+            Documents.RemoveAll(d
+                => d.DocumentId == document.DocumentId
+                && d.PartitionKey == document.PartitionKey);
+
+            document.ETag = Guid.NewGuid().ToString();
+            Documents.Add(document);
+
+            return Task.FromResult(document);
+        }
+
+        public virtual Task DeleteAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+        {
+            GuardExists(documentId, partitionKey);
+
+            Documents.RemoveAll(d
+                => d.DocumentId == documentId
+                && d.PartitionKey == partitionKey);
+
+            return Task.CompletedTask;
+        }
+
+        public Task<T> UpdateAsync(
+            string documentId,
+            string partitionKey,
+            Func<T, Task> updateDocument,
+            int retries = 0,
+            CancellationToken cancellationToken = default)
+        {
+            var document = GuardExists(documentId, partitionKey);
+            updateDocument(document);
+            document.ETag = Guid.NewGuid().ToString();
+
+            return Task.FromResult(document);
+        }
+
+        public Task<T> UpdateAsync(
+            string documentId,
+            string partitionKey,
+            Action<T> updateDocument,
+            int retries = 0,
+            CancellationToken cancellationToken = default)
+            => UpdateAsync(
+                documentId,
+                partitionKey,
+                d =>
+                {
+                    updateDocument(d);
+                    return Task.CompletedTask;
+                },
+                retries,
+                cancellationToken);
+
+        public Task<T> UpdateOrCreateAsync(
+            Func<T> getDefaultDocument,
+            Func<T, Task> updateDocument,
+            int retries = 0,
+            CancellationToken cancellationToken = default)
+        {
+            var defaultDocument = getDefaultDocument();
+            var existingDocument = Documents.Find(d
+                => d.DocumentId == defaultDocument.DocumentId
+                && d.PartitionKey == defaultDocument.PartitionKey);
+
+            var document = existingDocument ?? defaultDocument;
+            updateDocument(document);
+            document.ETag = Guid.NewGuid().ToString();
+
+            return Task.FromResult(document);
+        }
+
+        public Task<T> UpdateOrCreateAsync(
+            Func<T> getDefaultDocument,
+            Action<T> updateDocument,
+            int retries = 0,
+            CancellationToken cancellationToken = default)
+            => UpdateOrCreateAsync(
+                getDefaultDocument,
+                d =>
+                {
+                    updateDocument(d);
+                    return Task.CompletedTask;
+                },
+                retries,
+                cancellationToken);
+
+        private void GuardNotExists(
+            ICosmosResource document)
+        {
+            var existingDocument = Documents.Find(d
+                => d.DocumentId == document.DocumentId
+                && d.PartitionKey == document.PartitionKey);
+
+            if (existingDocument is not null)
+            {
+                throw new CosmosException(
+                    $"Document already exists.",
+                    HttpStatusCode.Conflict,
+                    0,
+                    string.Empty,
+                    0);
+            }
+        }
+
+        private void GuardExistsWithEtag(ICosmosResource document)
+        {
+            var existingDocument = GuardExists(document);
+            if (existingDocument.ETag != document.ETag)
+            {
+                throw new CosmosException(
+                    $"Document ETag does not match, " +
+                    $"indicating incorrecty document version.",
+                    HttpStatusCode.PreconditionFailed,
+                    0,
+                    string.Empty,
+                    0);
+            }
+        }
+
+        private T GuardExists(ICosmosResource document)
+            => GuardExists(document.DocumentId, document.PartitionKey);
+
+        private T GuardExists(
+            string documentId,
+            string partitionKey)
+        {
+            var item = Documents.Find(d
+                => d.DocumentId == documentId
+                && d.PartitionKey == partitionKey);
+
+            if (item is null)
+            {
+                throw new CosmosException(
+                    $"Document not found. " +
+                    $"Id: {documentId}. " +
+                    $"PartitionKey: {partitionKey}",
+                    HttpStatusCode.NotFound,
+                    0,
+                    string.Empty,
+                    0);
+            }
+
+            return item;
+        }
+    }
+}

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -55,3 +55,4 @@ dotnet_diagnostic.CA1812.severity = none            # Test classes used as gener
 dotnet_diagnostic.SA1202.severity = none            # Private helper methods makes sense to keep at top of test classes, as tests are added to bottom.
 dotnet_diagnostic.CA2201.severity = none            # Instantiating Exceptions as test data should be allowed.
 dotnet_diagnostic.MA0016.severity = none            # Prefer return collection abstraction instead of implementation
+dotnet_diagnostic.CA1002.severity = none            # Do not expose generic lists

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -54,4 +54,4 @@ dotnet_diagnostic.CA1062.severity = none            # Null checking input to tes
 dotnet_diagnostic.CA1812.severity = none            # Test classes used as generic arguments but not instantiated should be allowed.
 dotnet_diagnostic.SA1202.severity = none            # Private helper methods makes sense to keep at top of test classes, as tests are added to bottom.
 dotnet_diagnostic.CA2201.severity = none            # Instantiating Exceptions as test data should be allowed.
-
+dotnet_diagnostic.MA0016.severity = none            # Prefer return collection abstraction instead of implementation

--- a/test/Atc.Cosmos.Tests/CosmosBulkReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosBulkReaderTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Atc.Cosmos.Internal;

--- a/test/Atc.Cosmos.Tests/CosmosBulkWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosBulkWriterTests.cs
@@ -1,11 +1,9 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Atc.Cosmos.Internal;
 using Atc.Cosmos.Serialization;
 using Atc.Test;
 using AutoFixture;
-using AutoFixture.AutoNSubstitute;
 using FluentAssertions;
 using Microsoft.Azure.Cosmos;
 using NSubstitute;

--- a/test/Atc.Cosmos.Tests/CosmosReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosReaderTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Atc.Cosmos.Internal;

--- a/test/Atc.Cosmos.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/test/Atc.Cosmos.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -1,13 +1,8 @@
 using System;
-using System.Linq;
 using Atc.Cosmos.DependencyInjection;
 using Atc.Cosmos.Internal;
 using Atc.Cosmos.Serialization;
-using Atc.Test;
 using AutoFixture;
-using AutoFixture.Xunit2;
-using FluentAssertions;
-using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using NSubstitute;

--- a/test/Atc.Cosmos.Tests/Internal/CosmosClientProviderTests.cs
+++ b/test/Atc.Cosmos.Tests/Internal/CosmosClientProviderTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Text;
 using Atc.Cosmos.Internal;
 using Atc.Cosmos.Serialization;

--- a/test/Atc.Cosmos.Tests/Record.cs
+++ b/test/Atc.Cosmos.Tests/Record.cs
@@ -1,15 +1,17 @@
 namespace Atc.Cosmos.Tests
 {
-    public class Record : CosmosResource
+    public sealed class Record : ICosmosResource
     {
         public string Id { get; set; } = string.Empty;
 
         public string Pk { get; set; } = string.Empty;
 
-        protected override string GetDocumentId()
-            => Id;
+        public string? ETag { get; set; }
 
-        protected override string GetPartitionKey()
-            => Pk;
+        public string Data { get; set; }
+
+        string ICosmosResource.DocumentId => Id;
+
+        string ICosmosResource.PartitionKey => Pk;
     }
 }

--- a/test/Atc.Cosmos.Tests/RecordAggregate.cs
+++ b/test/Atc.Cosmos.Tests/RecordAggregate.cs
@@ -1,0 +1,7 @@
+namespace Atc.Cosmos.Tests
+{
+    public class RecordAggregate
+    {
+        public int Count { get; set; }
+    }
+}

--- a/test/Atc.Cosmos.Tests/Testng/FakeCosmosReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/Testng/FakeCosmosReaderTests.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Atc.Cosmos.Testing;
+using Atc.Test;
+using Dasync.Collections;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using Xunit;
+
+namespace Atc.Cosmos.Tests.Testng
+{
+    public class FakeCosmosReaderTests
+    {
+        [Theory, AutoNSubstituteData]
+        public async Task FindAsync_Should_Return_Document_When_Exists(
+            FakeCosmosReader<Record> sut,
+            Record record)
+        {
+            sut.Documents.Add(record);
+
+            var result = await sut.FindAsync(
+                record.Id,
+                record.Pk);
+
+            result
+                .Should()
+                .BeEquivalentTo(
+                    record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task FindAsync_Should_Return_Null_Not_Exists(
+            FakeCosmosReader<Record> sut,
+            Record record)
+        {
+            var result = await sut.FindAsync(
+                record.Id,
+                record.Pk);
+
+            result
+                .Should()
+                .BeNull();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAsync_Should_Return_Document_When_Exists(
+            FakeCosmosReader<Record> sut,
+            Record record)
+        {
+            sut.Documents.Add(record);
+
+            var result = await sut.ReadAsync(
+                record.Id,
+                record.Pk);
+
+            result
+                .Should()
+                .BeEquivalentTo(
+                    record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void ReadAsync_Should_Throw_When_Not_Exists(
+            FakeCosmosReader<Record> sut,
+            string documentId,
+            string partitionKey)
+        {
+            FluentActions.Awaiting(() => sut.ReadAsync(documentId, partitionKey))
+                .Should()
+                .Throw<CosmosException>()
+                .Where(e => e.StatusCode == System.Net.HttpStatusCode.NotFound);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAllAsync_Should_Return_All_Documents_With_PartitionKey(
+            FakeCosmosReader<Record> sut,
+            string partitionKey)
+        {
+            sut.Documents.ForEach(d => d.Pk = partitionKey);
+
+            var results = await sut
+                .ReadAllAsync(partitionKey)
+                .ToListAsync();
+
+            results
+                .Should()
+                .BeEquivalentTo(sut.Documents);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAllAsync_Should_Not_Return_Documents_With_Different_PartitionKey(
+            FakeCosmosReader<Record> sut,
+            string partitionKey)
+        {
+            var results = await sut
+                .ReadAllAsync(partitionKey)
+                .ToListAsync();
+
+            results
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Should_Return_All_Documents_With_PartitionKey(
+            FakeCosmosReader<Record> sut,
+            QueryDefinition query,
+            string partitionKey)
+        {
+            sut.Documents.ForEach(d => d.Pk = partitionKey);
+
+            var results = await sut
+                .QueryAsync(
+                    query,
+                    partitionKey)
+                .ToListAsync();
+
+            results
+                .Should()
+                .BeEquivalentTo(sut.Documents);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Should_Not_Return_Documents_With_Different_PartitionKey(
+            FakeCosmosReader<Record> sut,
+            QueryDefinition query,
+            string partitionKey)
+        {
+            var results = await sut
+                .QueryAsync(
+                    query,
+                    partitionKey)
+                .ToListAsync();
+
+            results
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Of_T_Should_Return_All_QueryResults_Of_Requested_Type(
+            FakeCosmosReader<Record> sut,
+            QueryDefinition query,
+            string partitionKey,
+            List<RecordAggregate> queryResults)
+        {
+            sut.QueryResults = queryResults.Cast<object>().ToList();
+
+            var results = await sut
+                .QueryAsync<RecordAggregate>(
+                    query,
+                    partitionKey)
+                .ToListAsync();
+
+            results
+                .Should()
+                .BeEquivalentTo(queryResults);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Of_T_Should_Not_Return_QueryResults_Of_Wrong_Type(
+            FakeCosmosReader<Record> sut,
+            QueryDefinition query,
+            string partitionKey,
+            List<object> queryResults)
+        {
+            sut.QueryResults = queryResults;
+
+            var results = await sut
+                .QueryAsync<RecordAggregate>(
+                    query,
+                    partitionKey)
+                .ToListAsync();
+
+            results
+                .Should()
+                .BeEmpty();
+        }
+    }
+}

--- a/test/Atc.Cosmos.Tests/Testng/FakeCosmosReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/Testng/FakeCosmosReaderTests.cs
@@ -1,9 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Atc.Cosmos.Testing;
 using Atc.Test;
+using AutoFixture.Xunit2;
 using Dasync.Collections;
 using FluentAssertions;
 using Microsoft.Azure.Cosmos;
@@ -177,6 +177,24 @@ namespace Atc.Cosmos.Tests.Testng
             results
                 .Should()
                 .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Be_Able_To_Inject_As_Frozen_CosmosReader(
+            [Frozen(Matching.ImplementedInterfaces)]
+            FakeCosmosReader<Record> sut,
+            TestCosmosService<Record> service)
+        {
+            service.Reader.Should().BeSameAs(sut);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Be_Able_To_Inject_As_Frozen_CosmosBulkReader(
+            [Frozen(Matching.ImplementedInterfaces)]
+            FakeCosmosReader<Record> sut,
+            TestCosmosService<Record> service)
+        {
+            service.BulkReader.Should().BeSameAs(sut);
         }
     }
 }

--- a/test/Atc.Cosmos.Tests/Testng/FakeCosmosTests.cs
+++ b/test/Atc.Cosmos.Tests/Testng/FakeCosmosTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Threading.Tasks;
+using Atc.Cosmos.Testing;
+using Atc.Test;
+using AutoFixture.AutoNSubstitute;
+using AutoFixture.Xunit2;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using NSubstitute;
+using Xunit;
+
+namespace Atc.Cosmos.Tests.Testng
+{
+    public class FakeCosmosTests
+    {
+        [Theory, AutoNSubstituteData]
+        public void Should_Have_Reader(
+            FakeCosmos<Record> sut)
+        {
+            sut.Reader.Should().NotBeNull();
+            sut.Reader.Documents.Should().BeSameAs(sut.Documents);
+            sut.Reader.QueryResults.Should().BeSameAs(sut.QueryResults);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Have_Writer(
+            FakeCosmos<Record> sut)
+        {
+            sut.Writer.Should().NotBeNull();
+            sut.Writer.Documents.Should().BeSameAs(sut.Documents);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Be_Able_To_Inject_As_Frozen_CosmosReader(
+            [Frozen(Matching.ImplementedInterfaces)]
+            FakeCosmos<Record> sut,
+            TestCosmosService<Record> service)
+        {
+            service.Reader.Should().BeSameAs(sut);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Be_Able_To_Inject_As_Frozen_CosmosBulkReader(
+            [Frozen(Matching.ImplementedInterfaces)]
+            FakeCosmos<Record> sut,
+            TestCosmosService<Record> service)
+        {
+            service.BulkReader.Should().BeSameAs(sut);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Be_Able_To_Inject_As_Frozen_CosmosWriter(
+            [Frozen(Matching.ImplementedInterfaces)]
+            FakeCosmos<Record> sut,
+            TestCosmosService<Record> service)
+        {
+            service.Writer.Should().BeSameAs(sut);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Be_Able_To_Inject_As_Frozen_CosmosBulkWriter(
+            [Frozen(Matching.ImplementedInterfaces)]
+            FakeCosmos<Record> sut,
+            TestCosmosService<Record> service)
+        {
+            service.BulkWriter.Should().BeSameAs(sut);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Forward_CosmosReader_Calls(
+            [Frozen, Substitute] FakeCosmosReader<Record> reader,
+            [Greedy] FakeCosmos<Record> sut,
+            string documentId,
+            string partitionKey,
+            QueryDefinition query)
+        {
+            var sutReader = (ICosmosReader<Record>)sut;
+            _ = sutReader.FindAsync(documentId, partitionKey);
+            _ = sutReader.ReadAsync(documentId, partitionKey);
+            sutReader.ReadAllAsync(partitionKey);
+            sutReader.QueryAsync(query, partitionKey);
+            sutReader.QueryAsync<RecordAggregate>(query, partitionKey);
+
+            _ = reader.Received(1).FindAsync(documentId, partitionKey);
+            _ = reader.Received(1).ReadAsync(documentId, partitionKey);
+            reader.Received(1).ReadAllAsync(partitionKey);
+            reader.Received(1).QueryAsync(query, partitionKey);
+            reader.Received(1).QueryAsync<RecordAggregate>(query, partitionKey);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Forward_CosmosWriter_Calls(
+            [Frozen, Substitute] FakeCosmosWriter<Record> writer,
+            [Greedy] FakeCosmos<Record> sut,
+            Record document,
+            string documentId,
+            string partitionKey,
+            Action<Record> updateDocument,
+            Func<Record, Task> updateDocumentAsync,
+            Func<Record> getDefaultDocument)
+        {
+            var sutWriter = (ICosmosWriter<Record>)sut;
+            _ = sutWriter.CreateAsync(document);
+            _ = sutWriter.WriteAsync(document);
+            _ = sutWriter.ReplaceAsync(document);
+            _ = sutWriter.DeleteAsync(documentId, partitionKey);
+            _ = sutWriter.UpdateAsync(documentId, partitionKey, updateDocument);
+            _ = sutWriter.UpdateAsync(documentId, partitionKey, updateDocumentAsync);
+            _ = sutWriter.UpdateOrCreateAsync(getDefaultDocument, updateDocument);
+            _ = sutWriter.UpdateOrCreateAsync(getDefaultDocument, updateDocumentAsync);
+
+            _ = writer.Received(1).CreateAsync(document);
+            _ = writer.Received(1).WriteAsync(document);
+            _ = writer.Received(1).ReplaceAsync(document);
+            _ = writer.Received(1).DeleteAsync(documentId, partitionKey);
+            _ = writer.Received(1).UpdateAsync(documentId, partitionKey, updateDocument);
+            _ = writer.Received(1).UpdateAsync(documentId, partitionKey, updateDocumentAsync);
+            _ = writer.Received(1).UpdateOrCreateAsync(getDefaultDocument, updateDocument);
+            _ = writer.Received(1).UpdateOrCreateAsync(getDefaultDocument, updateDocumentAsync);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Forward_CosmosBulkReader_Calls(
+            [Frozen, Substitute] FakeCosmosReader<Record> reader,
+            [Greedy] FakeCosmos<Record> sut,
+            string documentId,
+            string partitionKey,
+            QueryDefinition query)
+        {
+            var sutReader = (ICosmosBulkReader<Record>)sut;
+            _ = sutReader.FindAsync(documentId, partitionKey);
+            _ = sutReader.ReadAsync(documentId, partitionKey);
+            sutReader.ReadAllAsync(partitionKey);
+            sutReader.QueryAsync(query, partitionKey);
+            sutReader.QueryAsync<RecordAggregate>(query, partitionKey);
+
+            _ = reader.Received(1).FindAsync(documentId, partitionKey);
+            _ = reader.Received(1).ReadAsync(documentId, partitionKey);
+            reader.Received(1).ReadAllAsync(partitionKey);
+            reader.Received(1).QueryAsync(query, partitionKey);
+            reader.Received(1).QueryAsync<RecordAggregate>(query, partitionKey);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Forward_CosmosBulkWriter_Calls(
+            [Frozen, Substitute] FakeCosmosWriter<Record> writer,
+            [Greedy] FakeCosmos<Record> sut,
+            Record document,
+            string documentId,
+            string partitionKey)
+        {
+            var sutWriter = (ICosmosBulkWriter<Record>)sut;
+            _ = sutWriter.CreateAsync(document);
+            _ = sutWriter.WriteAsync(document);
+            _ = sutWriter.ReplaceAsync(document);
+            _ = sutWriter.DeleteAsync(documentId, partitionKey);
+
+            _ = writer.Received(1).CreateAsync(document);
+            _ = writer.Received(1).WriteAsync(document);
+            _ = writer.Received(1).ReplaceAsync(document);
+            _ = writer.Received(1).DeleteAsync(documentId, partitionKey);
+        }
+    }
+}

--- a/test/Atc.Cosmos.Tests/Testng/FakeCosmosWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/Testng/FakeCosmosWriterTests.cs
@@ -1,0 +1,347 @@
+using System;
+using System.Threading.Tasks;
+using Atc.Cosmos.Testing;
+using Atc.Test;
+using AutoFixture.AutoNSubstitute;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Atc.Cosmos.Tests.Testng
+{
+    public class FakeCosmosWriterTests
+    {
+        [Theory, AutoNSubstituteData]
+        public async Task CreateAsync_Should_Add_Document(
+            FakeCosmosWriter<Record> sut,
+            Record record)
+        {
+            await sut.CreateAsync(record);
+            sut.Documents
+                .Should()
+                .ContainEquivalentOf(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CreateAsync_Should_Return_Document_With_ETag(
+            FakeCosmosWriter<Record> sut,
+            Record record)
+        {
+            record.ETag = null;
+            var result = await sut.CreateAsync(record);
+            result.ETag
+                .Should()
+                .NotBeNullOrEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CreateAsync_Should_Throw_If_Document_Exists(
+            FakeCosmosWriter<Record> sut,
+            Record record)
+        {
+            sut.Documents.Add(record);
+            FluentActions.Awaiting(() => sut.CreateAsync(record))
+                .Should()
+                .Throw<CosmosException>()
+                .Where(e => e.StatusCode == System.Net.HttpStatusCode.Conflict);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task WriteAsync_Should_Add_Document(
+            FakeCosmosWriter<Record> sut,
+            Record record)
+        {
+            await sut.WriteAsync(record);
+            sut.Documents
+                .Should()
+                .ContainEquivalentOf(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task WriteAsync_Should_Return_Document_With_ETag(
+            FakeCosmosWriter<Record> sut,
+            Record record)
+        {
+            record.ETag = null;
+            var result = await sut.WriteAsync(record);
+            result.ETag
+                .Should()
+                .NotBeNullOrEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task WriteAsync_Should_Replace_Document_If_Exists(
+            FakeCosmosWriter<Record> sut,
+            Record record)
+        {
+            var existingDocument = new Record
+            {
+                Id = record.Id,
+                Pk = record.Pk,
+            };
+            sut.Documents.Add(existingDocument);
+
+            await sut.WriteAsync(record);
+            sut.Documents
+                .Should()
+                .NotContain(existingDocument)
+                .And
+                .ContainEquivalentOf(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void ReplaceAsync_Should_Throw_If_Document_Does_Not_Exists(
+            FakeCosmosWriter<Record> sut,
+            Record record)
+        {
+            FluentActions.Awaiting(() => sut.ReplaceAsync(record))
+                .Should()
+                .Throw<CosmosException>()
+                .Where(e => e.StatusCode == System.Net.HttpStatusCode.NotFound);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReplaceAsync_Should_Replace_Existing_Document(
+            FakeCosmosWriter<Record> sut,
+            Record record)
+        {
+            var existingDocument = new Record
+            {
+                Id = record.Id,
+                Pk = record.Pk,
+                ETag = record.ETag,
+            };
+            sut.Documents.Add(existingDocument);
+
+            await sut.ReplaceAsync(record);
+            sut.Documents
+                .Should()
+                .NotContain(existingDocument)
+                .And
+                .ContainEquivalentOf(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void ReplaceAsync_Should_Throw_If_Existing_Document_Has_Different_ETag(
+           FakeCosmosWriter<Record> sut,
+           Record record,
+           string differentETag)
+        {
+            var existingDocument = new Record
+            {
+                Id = record.Id,
+                Pk = record.Pk,
+                ETag = differentETag,
+            };
+            sut.Documents.Add(existingDocument);
+
+            FluentActions.Awaiting(() => sut.ReplaceAsync(record))
+                .Should()
+                .Throw<CosmosException>()
+                .Where(e => e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReplaceAsync_Should_Return_Document_With_ETag(
+            FakeCosmosWriter<Record> sut,
+            Record record)
+        {
+            sut.Documents.Add(new Record
+            {
+                Id = record.Id,
+                Pk = record.Pk,
+            });
+
+            record.ETag = null;
+            var result = await sut.ReplaceAsync(record);
+            result.ETag
+                .Should()
+                .NotBeNullOrEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void DeleteAsync_Should_Throw_If_Document_Does_Not_Exists(
+            FakeCosmosWriter<Record> sut,
+            string documentId,
+            string partitionKey)
+        {
+            FluentActions.Awaiting(() => sut.DeleteAsync(documentId, partitionKey))
+                .Should()
+                .Throw<CosmosException>()
+                .Where(e => e.StatusCode == System.Net.HttpStatusCode.NotFound);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task DeleteAsync_Should_Replace_Existing_Document(
+            FakeCosmosWriter<Record> sut,
+            Record record)
+        {
+            var existingDocument = new Record
+            {
+                Id = record.Id,
+                Pk = record.Pk,
+            };
+            sut.Documents.Add(existingDocument);
+
+            await sut.DeleteAsync(record.Id, record.Pk);
+            sut.Documents
+                .Should()
+                .NotContain(existingDocument);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void UpdateAsync_Should_Throw_If_Document_Does_Not_Exists(
+             FakeCosmosWriter<Record> sut,
+             string documentId,
+             string partitionKey)
+        {
+            FluentActions.Awaiting(() => sut
+                .UpdateAsync(
+                    documentId,
+                    partitionKey,
+                    d => { }))
+                .Should()
+                .Throw<CosmosException>()
+                .Where(e => e.StatusCode == System.Net.HttpStatusCode.NotFound);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateAsync_Should_Call_UpdateDocument_Delegate(
+             FakeCosmosWriter<Record> sut,
+             Record record,
+             [Substitute] Action<Record> updateDocument)
+        {
+            sut.Documents.Add(record);
+
+            await sut.UpdateAsync(
+                record.Id,
+                record.Pk,
+                updateDocument);
+
+            updateDocument
+                .Received(1)
+                .Invoke(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateAsync_Should_Return_Updated_Document(
+             FakeCosmosWriter<Record> sut,
+             Record record,
+             string newData)
+        {
+            record.ETag = null;
+            sut.Documents.Add(record);
+
+            var result = await sut.UpdateAsync(
+                record.Id,
+                record.Pk,
+                d => d.Data = newData);
+
+            result
+                .Should()
+                .BeEquivalentTo(
+                    new Record
+                    {
+                        Id = record.Id,
+                        Pk = record.Pk,
+                        Data = newData,
+                    },
+                    o => o.Excluding(r => r.ETag));
+
+            result.ETag
+                .Should()
+                .NotBeNullOrEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateOrCreateAsync_Should_Call_GetDefaultDocument_Delegate(
+             FakeCosmosWriter<Record> sut,
+             Record defaultDocument,
+             [Substitute] Func<Record> getDefaultDocument,
+             [Substitute] Action<Record> updateDocument)
+        {
+            getDefaultDocument
+                .Invoke()
+                .Returns(defaultDocument);
+
+            await sut.UpdateOrCreateAsync(getDefaultDocument, updateDocument);
+
+            getDefaultDocument
+                .Received(1)
+                .Invoke();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateOrCreateAsync_Should_Call_UpdateDocument_With_DefaultDocument(
+             FakeCosmosWriter<Record> sut,
+             Record defaultDocument,
+             [Substitute] Action<Record> updateDocument)
+        {
+            await sut.UpdateOrCreateAsync(
+                () => defaultDocument,
+                updateDocument);
+
+            updateDocument
+                .Received(1)
+                .Invoke(defaultDocument);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateOrCreateAsync_Should_Call_UpdateDocument_With_ExistingDocument(
+             FakeCosmosWriter<Record> sut,
+             Record existingDocument,
+             [Substitute] Action<Record> updateDocument)
+        {
+            sut.Documents.Add(existingDocument);
+            var defaultDocument = new Record
+            {
+                Id = existingDocument.Id,
+                Pk = existingDocument.Pk,
+            };
+
+            await sut.UpdateOrCreateAsync(
+                () => defaultDocument,
+                updateDocument);
+
+            updateDocument
+                .Received(1)
+                .Invoke(existingDocument);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateOrCreateAsync_Should_Return_Updated_Document(
+             FakeCosmosWriter<Record> sut,
+             Record document,
+             string newData)
+        {
+            document.ETag = null;
+            sut.Documents.Add(document);
+            var defaultDocument = new Record
+            {
+                Id = document.Id,
+                Pk = document.Pk,
+            };
+
+            var result = await sut.UpdateOrCreateAsync(
+                () => defaultDocument,
+                d => d.Data = newData);
+
+            result
+                .Should()
+                .BeEquivalentTo(
+                    new Record
+                    {
+                        Id = document.Id,
+                        Pk = document.Pk,
+                        Data = newData,
+                    },
+                    o => o.Excluding(r => r.ETag));
+
+            result.ETag
+                .Should()
+                .NotBeNullOrEmpty();
+        }
+    }
+}

--- a/test/Atc.Cosmos.Tests/Testng/FakeCosmosWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/Testng/FakeCosmosWriterTests.cs
@@ -3,10 +3,10 @@ using System.Threading.Tasks;
 using Atc.Cosmos.Testing;
 using Atc.Test;
 using AutoFixture.AutoNSubstitute;
+using AutoFixture.Xunit2;
 using FluentAssertions;
 using Microsoft.Azure.Cosmos;
 using NSubstitute;
-using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace Atc.Cosmos.Tests.Testng
@@ -342,6 +342,24 @@ namespace Atc.Cosmos.Tests.Testng
             result.ETag
                 .Should()
                 .NotBeNullOrEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Be_Able_To_Inject_As_Frozen_CosmosWriter(
+            [Frozen(Matching.ImplementedInterfaces)]
+            FakeCosmosWriter<Record> sut,
+            TestCosmosService<Record> service)
+        {
+            service.Writer.Should().BeSameAs(sut);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Should_Be_Able_To_Inject_As_Frozen_CosmosBulkWriter(
+            [Frozen(Matching.ImplementedInterfaces)]
+            FakeCosmosWriter<Record> sut,
+            TestCosmosService<Record> service)
+        {
+            service.BulkWriter.Should().BeSameAs(sut);
         }
     }
 }

--- a/test/Atc.Cosmos.Tests/Testng/TestCosmosService.cs
+++ b/test/Atc.Cosmos.Tests/Testng/TestCosmosService.cs
@@ -1,0 +1,26 @@
+namespace Atc.Cosmos.Tests.Testng
+{
+    public class TestCosmosService<T>
+        where T : class, ICosmosResource
+    {
+        public TestCosmosService(
+            ICosmosReader<T> reader,
+            ICosmosWriter<T> writer,
+            ICosmosBulkReader<T> bulkReader,
+            ICosmosBulkWriter<T> bulkWriter)
+        {
+            Reader = reader;
+            Writer = writer;
+            BulkReader = bulkReader;
+            BulkWriter = bulkWriter;
+        }
+
+        public ICosmosReader<T> Reader { get; }
+
+        public ICosmosWriter<T> Writer { get; }
+
+        public ICosmosBulkReader<T> BulkReader { get; }
+
+        public ICosmosBulkWriter<T> BulkWriter { get; }
+    }
+}


### PR DESCRIPTION
This PR adds fakes for making unit testing with Cosmos readers and writers easier.

The following fakes are added:
* `FakeCosmosReader`; that implements both ICosmosReader<T> and ICosmosBulkReader<T>
* `FakeCosmosWriter`; that implements both ICosmosWriter<T> and ICosmosBulkWriter<T>
* `FakeCosmos`; that implements both readers and writers and connects their state

Especially the testing of calls to `UpdateAsync` and `UpdateOrCreateAsync` can be hard to test given the delegates being passed into these functions. 

A test for these would previously require setup code for mimicking the correct call behaviour, like this:

```csharp
[Theory, AutoNSubstituteData]
public async Task Should_Return_BootNotificationState(
    [Frozen] ICosmosWriter<BootNotificationState> writer,
    BootNotificationStateWriter sut,
    string chargePointId,
    BootNotificationRequest request,
    DateTimeOffset timestamp,
    CancellationToken cancellationToken,
    BootNotificationState state)
{
    writer
        .UpdateOrCreateAsync(
            Arg.Do<Func<BootNotificationState>>(a => a()),
            Arg.Do<Action<BootNotificationState>>(a => a(state)),
            retries: 5,
            cancellationToken)
        .ReturnsForAnyArgs(state);

    var result = await sut.WriteAsync(chargePointId, request, timestamp, cancellationToken);
    result
        .Should()
        .Be(state);
}
```

But can now use the `FakeCosmosWriter` like this:
```csharp
[Theory, AutoNSubstituteData]
public async Task Should_Return_BootNotificationState_New(
    [Frozen(Matching.ImplementedInterfaces)]
    FakeCosmosWriter<BootNotificationState> writer,
    BootNotificationStateWriter sut,
    string chargePointId,
    BootNotificationRequest request,
    DateTimeOffset timestamp,
    CancellationToken cancellationToken)
{
    var result = await sut.WriteAsync(chargePointId, request, timestamp, cancellationToken);
    result
        .Should()
        .BeEquivalentTo(request);
}
```

Or include asset that state is updated like this:
```csharp
[Theory, AutoNSubstituteData]
public async Task Should_Return_BootNotificationState_New(
    [Frozen(Matching.ImplementedInterfaces)]
    FakeCosmosWriter<BootNotificationState> writer,
    BootNotificationStateWriter sut,
    string chargePointId,
    BootNotificationRequest request,
    DateTimeOffset timestamp,
    CancellationToken cancellationToken,
    BootNotificationState state)
{
    state.ChargePointId = chargePointId;
    writer.Documents.Add(state);

    var result = await sut.WriteAsync(chargePointId, request, timestamp, cancellationToken);
    result
        .Should()
        .Be(state)
        .And
        .BeEquivalentTo(request);
}
```