### PR TITLE
Document collection is updated with non-existing document

### DIFF
--- a/src/Atc.Cosmos/Testing/FakeCosmosWriter.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmosWriter.cs
@@ -139,7 +139,12 @@ namespace Atc.Cosmos.Testing
 
             var document = existingDocument ?? defaultDocument;
             updateDocument(document);
+
             document.ETag = Guid.NewGuid().ToString();
+            if (existingDocument is null)
+            {
+                Documents.Add(defaultDocument);
+            }
 
             return Task.FromResult(document);
         }

--- a/test/Atc.Cosmos.Tests/Testng/FakeCosmosWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/Testng/FakeCosmosWriterTests.cs
@@ -289,6 +289,19 @@ namespace Atc.Cosmos.Tests.Testng
         }
 
         [Theory, AutoNSubstituteData]
+        public async Task UpdateOrCreateAsync_Should_Add_NonExisting_Document(
+             FakeCosmosWriter<Record> sut,
+             Record defaultDocument,
+             [Substitute] Action<Record> updateDocument)
+        {
+            await sut.UpdateOrCreateAsync(
+                () => defaultDocument,
+                updateDocument);
+
+            sut.Documents.Should().Contain(defaultDocument);
+        }
+
+        [Theory, AutoNSubstituteData]
         public async Task UpdateOrCreateAsync_Should_Call_UpdateDocument_With_ExistingDocument(
              FakeCosmosWriter<Record> sut,
              Record existingDocument,


### PR DESCRIPTION
Calls to FakeCosmosWriter.UpdateOrCreateAsync() will add non-existing document to internal Documents collection.