### PR TITLE
Introduce optimized write operations

### DIFF
--- a/src/Atc.Cosmos/ICosmosWriter.cs
+++ b/src/Atc.Cosmos/ICosmosWriter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,12 +32,41 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Creates a new <typeparamref name="T"/> resource in Cosmos.
+        /// </summary>
+        /// <remarks>
+        /// This is optimal for workloads where the returned resource is not used.
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.Conflict"/>
+        /// will be thrown if a resource already exists.
+        /// </remarks>
+        /// <param name="document">The resource to be created.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task CreateWithNoResponseAsync(
+            T document,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Writes a <typeparamref name="T"/> resource to Cosmos, using upsert behavior.
         /// </summary>
         /// <param name="document">The resource to be written.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
         /// <returns>A <see cref="Task"/> containing the written <typeparamref name="T"/> resource.</returns>
         Task<T> WriteAsync(
+            T document,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Writes a <typeparamref name="T"/> resource to Cosmos, using upsert behavior.
+        /// </summary>
+        /// <remarks>
+        /// This is optimal for workloads where the returned resource is not used.
+        /// </remarks>
+        /// <param name="document">The resource to be written.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task WriteWithNoResponseAsync(
             T document,
             CancellationToken cancellationToken = default);
 
@@ -61,6 +90,30 @@ namespace Atc.Cosmos
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
         /// <returns>A <see cref="Task"/> containing the updated <typeparamref name="T"/> resource.</returns>
         Task<T> ReplaceAsync(
+            T document,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Replaces a <typeparamref name="T"/> resource in Cosmos.
+        /// </summary>
+        /// <remarks>
+        /// This is optimal for workloads where the returned resource is not used.
+        /// <para>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.NotFound"/>
+        /// will be thrown if the resource does not already exist in Cosmos.
+        /// </para>
+        /// <para>
+        /// A <see cref="CosmosException"/>
+        /// with StatusCode <see cref="HttpStatusCode.PreconditionFailed"/>
+        /// will be thrown if the resource has been updated since it was read
+        /// (using the <see cref="ICosmosResource.ETag"/> to match the version).
+        /// </para>
+        /// </remarks>
+        /// <param name="document">The resource to be created.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task ReplaceWithNoResponseAsync(
             T document,
             CancellationToken cancellationToken = default);
 

--- a/src/Atc.Cosmos/Internal/CosmosWriter.cs
+++ b/src/Atc.Cosmos/Internal/CosmosWriter.cs
@@ -37,6 +37,16 @@ namespace Atc.Cosmos.Internal
                     cancellationToken)
                 .GetResourceWithEtag<T>(serializer);
 
+        public Task CreateWithNoResponseAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+            => container
+                .CreateItemAsync<object>(
+                    document,
+                    new PartitionKey(document.PartitionKey),
+                    new ItemRequestOptions { EnableContentResponseOnWrite = false },
+                    cancellationToken);
+
         public Task<T> WriteAsync(
             T document,
             CancellationToken cancellationToken = default)
@@ -47,6 +57,16 @@ namespace Atc.Cosmos.Internal
                     new ItemRequestOptions { },
                     cancellationToken)
                 .GetResourceWithEtag<T>(serializer);
+
+        public Task WriteWithNoResponseAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+            => container
+                .UpsertItemAsync<object>(
+                    document,
+                    new PartitionKey(document.PartitionKey),
+                    new ItemRequestOptions { EnableContentResponseOnWrite = false },
+                    cancellationToken);
 
         public Task<T> ReplaceAsync(
             T document,
@@ -62,6 +82,21 @@ namespace Atc.Cosmos.Internal
                     },
                     cancellationToken)
                 .GetResourceWithEtag<T>(serializer);
+
+        public Task ReplaceWithNoResponseAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+            => container
+                .ReplaceItemAsync<object>(
+                    document,
+                    document.DocumentId,
+                    new PartitionKey(document.PartitionKey),
+                    new ItemRequestOptions
+                    {
+                        IfMatchEtag = document.ETag,
+                        EnableContentResponseOnWrite = false,
+                    },
+                    cancellationToken);
 
         public Task DeleteAsync(
             string documentId,

--- a/src/Atc.Cosmos/Testing/FakeCosmos.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmos.cs
@@ -177,6 +177,14 @@ namespace Atc.Cosmos.Testing
                     document,
                     cancellationToken);
 
+        Task ICosmosWriter<T>.CreateWithNoResponseAsync(
+            T document,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .CreateWithNoResponseAsync(
+                    document,
+                    cancellationToken);
+
         Task<T> ICosmosWriter<T>.WriteAsync(
             T document,
             CancellationToken cancellationToken)
@@ -185,11 +193,27 @@ namespace Atc.Cosmos.Testing
                     document,
                     cancellationToken);
 
+        Task ICosmosWriter<T>.WriteWithNoResponseAsync(
+            T document,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .WriteWithNoResponseAsync(
+                    document,
+                    cancellationToken);
+
         Task<T> ICosmosWriter<T>.ReplaceAsync(
             T document,
             CancellationToken cancellationToken)
             => ((ICosmosWriter<T>)Writer)
                 .ReplaceAsync(
+                    document,
+                    cancellationToken);
+
+        Task ICosmosWriter<T>.ReplaceWithNoResponseAsync(
+            T document,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .ReplaceWithNoResponseAsync(
                     document,
                     cancellationToken);
 

--- a/src/Atc.Cosmos/Testing/FakeCosmosWriter.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmosWriter.cs
@@ -64,6 +64,11 @@ namespace Atc.Cosmos.Testing
             return Task.FromResult(newDocument);
         }
 
+        public virtual Task CreateWithNoResponseAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+            => CreateAsync(document, cancellationToken);
+
         public virtual Task<T> WriteAsync(
             T document,
             CancellationToken cancellationToken = default)
@@ -78,6 +83,11 @@ namespace Atc.Cosmos.Testing
 
             return Task.FromResult(newDocument);
         }
+
+        public virtual Task WriteWithNoResponseAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+            => WriteAsync(document, cancellationToken);
 
         public virtual Task<T> ReplaceAsync(
             T document,
@@ -95,6 +105,11 @@ namespace Atc.Cosmos.Testing
 
             return Task.FromResult(newDocument);
         }
+
+        public virtual Task ReplaceWithNoResponseAsync(
+            T document,
+            CancellationToken cancellationToken = default)
+            => ReplaceAsync(document, cancellationToken);
 
         public virtual Task DeleteAsync(
             string documentId,

--- a/test/Atc.Cosmos.Tests/CosmosWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosWriterTests.cs
@@ -92,6 +92,24 @@ namespace Atc.Cosmos.Tests
         }
 
         [Theory, AutoNSubstituteData]
+        public async Task WriteWithNoResponseAsync_UpsertItem_In_Container(
+            CancellationToken cancellationToken)
+        {
+            containerProvider
+                .GetContainer<Record>()
+                .ReturnsForAnyArgs(container);
+
+            await sut.WriteWithNoResponseAsync(record, cancellationToken);
+            await container
+                .Received(1)
+                .UpsertItemAsync<object>(
+                    record,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(p => p.EnableContentResponseOnWrite == false),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
         public async Task CreateAsync_Calls_CreateItem_On_Container(
            CancellationToken cancellationToken)
         {
@@ -102,6 +120,20 @@ namespace Atc.Cosmos.Tests
                     record,
                     new PartitionKey(record.Pk),
                     Arg.Any<ItemRequestOptions>(),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CreateWithNoResponseAsync_Calls_CreateItem_On_Container(
+           CancellationToken cancellationToken)
+        {
+            await sut.CreateWithNoResponseAsync(record, cancellationToken);
+            _ = container
+                .Received(1)
+                .CreateItemAsync<object>(
+                    record,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(p => p.EnableContentResponseOnWrite == false),
                     cancellationToken);
         }
 
@@ -117,6 +149,22 @@ namespace Atc.Cosmos.Tests
                     record.Id,
                     new PartitionKey(record.Pk),
                     Arg.Is<ItemRequestOptions>(o => o.IfMatchEtag == ((ICosmosResource)record).ETag),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReplaceWithNoResponseAsync_Calls_ReplaceItemAsync_On_Container(
+           CancellationToken cancellationToken)
+        {
+            await sut.ReplaceWithNoResponseAsync(record, cancellationToken);
+            _ = container
+                .Received(1)
+                .ReplaceItemAsync<object>(
+                    record,
+                    record.Id,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.IfMatchEtag == ((ICosmosResource)record).ETag
+                                                 && o.EnableContentResponseOnWrite == false),
                     cancellationToken);
         }
 


### PR DESCRIPTION
This PR introduces 3 new methods for writing a resource to cosmos optimized for speed.
```c#
Task CreateWithNoResponseAsync(T document, CancellationToken cancellationToken = default);
Task WriteWithNoResponseAsync(T document, CancellationToken cancellationToken = default);
Task ReplaceWithNoResponseAsync(T document, CancellationToken cancellationToken = default);
```
By setting the request option `EnableContentResponseOnWrite` to `false` it reduces networking and CPU load by not sending the resource back over the network and serializing it on the client.