### PR TITLE
Downgrade Microsoft.Extensions.Options to 3.1.17

### DIFF
--- a/src/Atc.Cosmos/Atc.Cosmos.csproj
+++ b/src/Atc.Cosmos/Atc.Cosmos.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.18.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.17" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Downgrade Microsoft.Extensions.Options to 3.1.17 as the 5.0.0 version caused problems on Azure Functions running netcoreapp3.1.