### PR TITLE
Feature/generics

### DIFF
--- a/src/Atc.Cosmos/DependencyInjection/CosmosBuilder.cs
+++ b/src/Atc.Cosmos/DependencyInjection/CosmosBuilder.cs
@@ -41,6 +41,16 @@ namespace Atc.Cosmos.DependencyInjection
             return AddContainer<TResource>(name);
         }
 
+        public ICosmosBuilder AddContainer<TInitializer>(
+            Type resourceType,
+            string name)
+            where TInitializer : class, ICosmosContainerInitializer
+        {
+            Services.AddSingleton<ICosmosContainerInitializer, TInitializer>();
+
+            return AddContainer(resourceType, name);
+        }
+
         public ICosmosBuilder<TResource> AddContainer<TResource>(
             string name)
             where TResource : class, ICosmosResource
@@ -49,6 +59,16 @@ namespace Atc.Cosmos.DependencyInjection
                 new CosmosContainerNameProvider<TResource>(name));
 
             return new CosmosBuilder<TResource>(Services);
+        }
+
+        public ICosmosBuilder AddContainer(
+            Type resourceType,
+            string name)
+        {
+            Services.AddSingleton<ICosmosContainerNameProvider>(
+                new CosmosContainerNameProvider(resourceType, name));
+
+            return this;
         }
 
         public ICosmosBuilder UseHostedService()

--- a/src/Atc.Cosmos/DependencyInjection/CosmosContainerBuilder.cs
+++ b/src/Atc.Cosmos/DependencyInjection/CosmosContainerBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using Atc.Cosmos.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -26,6 +27,15 @@ namespace Atc.Cosmos.DependencyInjection
             return new CosmosContainerBuilder<TResource>(
                 ContainerName,
                 Services);
+        }
+
+        public ICosmosContainerBuilder AddResource(
+            Type resourceType)
+        {
+            Services.AddSingleton<ICosmosContainerNameProvider>(
+                new CosmosContainerNameProvider(resourceType, ContainerName));
+
+            return this;
         }
     }
 }

--- a/src/Atc.Cosmos/DependencyInjection/ICosmosBuilder.cs
+++ b/src/Atc.Cosmos/DependencyInjection/ICosmosBuilder.cs
@@ -58,6 +58,23 @@ namespace Atc.Cosmos.DependencyInjection
             where TResource : class, ICosmosResource;
 
         /// <summary>
+        /// Adds a container with an initializer and a resource type.
+        /// </summary>
+        /// <typeparam name="TInitializer">
+        /// The <see cref="ICosmosContainerInitializer"/> to be
+        /// used for initializing the container.
+        /// </typeparam>
+        /// <param name="resourceType">
+        /// The <see cref="ICosmosResource"/> to be used for
+        /// representing document resources in the container.</param>
+        /// <param name="name">The name of the container.</param>
+        /// <returns>The <see cref="ICosmosBuilder"/> instance.</returns>
+        ICosmosBuilder AddContainer<TInitializer>(
+            Type resourceType,
+            string name)
+            where TInitializer : class, ICosmosContainerInitializer;
+
+        /// <summary>
         /// Adds a container with a resource type.
         /// </summary>
         /// <typeparam name="TResource">
@@ -69,6 +86,19 @@ namespace Atc.Cosmos.DependencyInjection
         ICosmosBuilder<TResource> AddContainer<TResource>(
             string name)
             where TResource : class, ICosmosResource;
+
+        /// <summary>
+        /// Adds a container with a resource type.
+        /// </summary>
+        /// <param name="resourceType">
+        /// The <see cref="ICosmosResource"/> to be used for
+        /// representing document resources in the container.
+        /// </param>
+        /// <param name="name">The name of the container.</param>
+        /// <returns>The <see cref="ICosmosBuilder"/> instance.</returns>
+        ICosmosBuilder AddContainer(
+            Type resourceType,
+            string name);
 
         /// <summary>
         /// Configures a <see cref="IHostedService"/> for running the

--- a/src/Atc.Cosmos/DependencyInjection/ICosmosContainerBuilder.cs
+++ b/src/Atc.Cosmos/DependencyInjection/ICosmosContainerBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Atc.Cosmos.DependencyInjection
@@ -28,5 +29,17 @@ namespace Atc.Cosmos.DependencyInjection
         /// <returns>An <see cref="ICosmosContainerBuilder" /> for configuring the container.</returns>
         ICosmosContainerBuilder<T> AddResource<T>()
             where T : class, ICosmosResource;
+
+        /// <summary>
+        /// Adds a <see cref="ICosmosResource"/> to be used for
+        /// representing document resources in the container.
+        /// </summary>
+        /// <param name="resourceType">
+        /// The <see cref="ICosmosResource"/> to be used for
+        /// representing document resources in the container.
+        /// </param>
+        /// <returns>An <see cref="ICosmosContainerBuilder" /> for configuring the container.</returns>
+        ICosmosContainerBuilder AddResource(
+            Type resourceType);
     }
 }

--- a/src/Atc.Cosmos/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Atc.Cosmos/DependencyInjection/ServiceCollectionExtensions.cs
@@ -62,6 +62,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ICosmosInitializer, CosmosInitializer>();
             services.AddSingleton<IJsonCosmosSerializer, JsonCosmosSerializer>();
             services.AddSingleton<ICosmosClientProvider, CosmosClientProvider>();
+            services.AddSingleton<ICosmosReaderFactory, CosmosReaderFactory>();
+            services.AddSingleton<ICosmosWriterFactory, CosmosWriterFactory>();
 
             builder(new CosmosBuilder(services));
             return services;

--- a/src/Atc.Cosmos/IChangeFeedListener{T}.cs
+++ b/src/Atc.Cosmos/IChangeFeedListener{T}.cs
@@ -1,0 +1,14 @@
+using Atc.Cosmos.Internal;
+
+namespace Atc.Cosmos
+{
+    /// <summary>
+    /// Represents a change feed listener for a specific <see cref="ICosmosResource"/>
+    /// and can be used to start and stop the listening for changes.
+    /// </summary>
+    /// <typeparam name="T">The <see cref="ICosmosResource"/>.</typeparam>
+    public interface IChangeFeedListener<T> : IChangeFeedListener
+        where T : class, ICosmosResource
+    {
+    }
+}

--- a/src/Atc.Cosmos/ICosmosReaderFactory.cs
+++ b/src/Atc.Cosmos/ICosmosReaderFactory.cs
@@ -1,0 +1,24 @@
+namespace Atc.Cosmos
+{
+    /// <summary>
+    /// Represents a factory for creating <see cref="ICosmosReader{T}"/> instances.
+    /// </summary>
+    public interface ICosmosReaderFactory
+    {
+        /// <summary>
+        /// Create a <see cref="ICosmosReader{T}"/>.
+        /// </summary>
+        /// <typeparam name="TResource">The <see cref="ICosmosResource"/> for the <see cref="ICosmosReader{T}"/>.</typeparam>
+        /// <returns>A <see cref="ICosmosReader{T}"/>.</returns>
+        ICosmosReader<TResource> CreateReader<TResource>()
+            where TResource : class, ICosmosResource;
+
+        /// <summary>
+        /// Create a <see cref="ICosmosBulkReader{T}"/>.
+        /// </summary>
+        /// <typeparam name="TResource">The <see cref="ICosmosResource"/> for the <see cref="ICosmosBulkReader{T}"/>.</typeparam>
+        /// <returns>A <see cref="ICosmosBulkReader{T}"/>.</returns>
+        ICosmosBulkReader<TResource> CreateBulkReader<TResource>()
+            where TResource : class, ICosmosResource;
+    }
+}

--- a/src/Atc.Cosmos/ICosmosWriterFactory.cs
+++ b/src/Atc.Cosmos/ICosmosWriterFactory.cs
@@ -1,0 +1,24 @@
+namespace Atc.Cosmos
+{
+    /// <summary>
+    /// Represents a factory for creating <see cref="ICosmosWriter{T}"/> instances.
+    /// </summary>
+    public interface ICosmosWriterFactory
+    {
+        /// <summary>
+        /// Create a <see cref="ICosmosWriter{T}"/>.
+        /// </summary>
+        /// <typeparam name="TResource">The <see cref="ICosmosResource"/> for the <see cref="ICosmosWriter{T}"/>.</typeparam>
+        /// <returns>A <see cref="ICosmosWriter{T}"/>.</returns>
+        ICosmosWriter<TResource> CreateWriter<TResource>()
+            where TResource : class, ICosmosResource;
+
+        /// <summary>
+        /// Create a <see cref="ICosmosBulkWriter{T}"/>.
+        /// </summary>
+        /// <typeparam name="TResource">The <see cref="ICosmosResource"/> for the <see cref="ICosmosBulkWriter{T}"/>.</typeparam>
+        /// <returns>A <see cref="ICosmosBulkWriter{T}"/>.</returns>
+        ICosmosBulkWriter<TResource> CreateBulkWriter<TResource>()
+            where TResource : class, ICosmosResource;
+    }
+}

--- a/src/Atc.Cosmos/Internal/CosmosContainerNameProvider.cs
+++ b/src/Atc.Cosmos/Internal/CosmosContainerNameProvider.cs
@@ -2,17 +2,34 @@ using System;
 
 namespace Atc.Cosmos.Internal
 {
-    public class CosmosContainerNameProvider<T> : ICosmosContainerNameProvider
-        where T : ICosmosResource
+    public class CosmosContainerNameProvider : ICosmosContainerNameProvider
     {
+        private readonly Type containerType;
+        private readonly string containerName;
+
         public CosmosContainerNameProvider(
+            Type resourceType,
             string containerName)
         {
-            ContainerName = containerName;
+            this.containerType = resourceType;
+            this.containerName = containerName;
         }
 
-        public Type FromType => typeof(T);
+        public string? GetContainerName(Type resourceType)
+        {
+            if (containerType.IsGenericTypeDefinition)
+            {
+                if (resourceType.GetGenericTypeDefinition() == containerType)
+                {
+                    return containerName;
+                }
+            }
+            else if (containerType == resourceType)
+            {
+                return containerName;
+            }
 
-        public string ContainerName { get; }
+            return null;
+        }
     }
 }

--- a/src/Atc.Cosmos/Internal/CosmosContainerNameProvider{T}.cs
+++ b/src/Atc.Cosmos/Internal/CosmosContainerNameProvider{T}.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Atc.Cosmos.Internal
+{
+    public class CosmosContainerNameProvider<T> : ICosmosContainerNameProvider
+        where T : ICosmosResource
+    {
+        private readonly string containerName;
+
+        public CosmosContainerNameProvider(
+            string containerName)
+        {
+            this.containerName = containerName;
+        }
+
+        public string? GetContainerName(Type resourceType)
+            => typeof(T) == resourceType
+             ? containerName
+             : null;
+    }
+}

--- a/src/Atc.Cosmos/Internal/CosmosReaderFactory.cs
+++ b/src/Atc.Cosmos/Internal/CosmosReaderFactory.cs
@@ -1,0 +1,23 @@
+using Atc.Cosmos.Serialization;
+
+namespace Atc.Cosmos.Internal
+{
+    public class CosmosReaderFactory : ICosmosReaderFactory
+    {
+        private readonly ICosmosContainerProvider provider;
+
+        public CosmosReaderFactory(
+            ICosmosContainerProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        public ICosmosReader<TResource> CreateReader<TResource>()
+            where TResource : class, ICosmosResource
+            => new CosmosReader<TResource>(provider);
+
+        public ICosmosBulkReader<TResource> CreateBulkReader<TResource>()
+            where TResource : class, ICosmosResource
+            => new CosmosBulkReader<TResource>(provider);
+    }
+}

--- a/src/Atc.Cosmos/Internal/CosmosWriterFactory.cs
+++ b/src/Atc.Cosmos/Internal/CosmosWriterFactory.cs
@@ -1,0 +1,34 @@
+using Atc.Cosmos.Serialization;
+
+namespace Atc.Cosmos.Internal
+{
+    public class CosmosWriterFactory : ICosmosWriterFactory
+    {
+        private readonly ICosmosContainerProvider provider;
+        private readonly IJsonCosmosSerializer serializer;
+        private readonly ICosmosReaderFactory factory;
+
+        public CosmosWriterFactory(
+            ICosmosContainerProvider provider,
+            IJsonCosmosSerializer serializer,
+            ICosmosReaderFactory factory)
+        {
+            this.provider = provider;
+            this.serializer = serializer;
+            this.factory = factory;
+        }
+
+        public ICosmosWriter<TResource> CreateWriter<TResource>()
+            where TResource : class, ICosmosResource
+            => new CosmosWriter<TResource>(
+                provider,
+                factory.CreateReader<TResource>(),
+                serializer);
+
+        public ICosmosBulkWriter<TResource> CreateBulkWriter<TResource>()
+            where TResource : class, ICosmosResource
+            => new CosmosBulkWriter<TResource>(
+                provider,
+                serializer);
+    }
+}

--- a/src/Atc.Cosmos/Internal/IChangeFeedFactory.cs
+++ b/src/Atc.Cosmos/Internal/IChangeFeedFactory.cs
@@ -2,8 +2,20 @@ using Microsoft.Azure.Cosmos;
 
 namespace Atc.Cosmos.Internal
 {
+    /// <summary>
+    /// Represents a factory for creating a <see cref="ChangeFeedProcessor"/>
+    /// for a <see cref="ICosmosResource"/>.
+    /// </summary>
     public interface IChangeFeedFactory
     {
+        /// <summary>
+        /// Create a <see cref="ChangeFeedProcessor"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="ICosmosResource"/>.</typeparam>
+        /// <param name="onChanges">Delegate to receive changes.</param>
+        /// <param name="onError">A delegate to receive notifications for change feed processor related errors.</param>
+        /// <param name="processorName">A name that identifies the Processor and the particular work it will do.</param>
+        /// <returns>A <see cref="ChangeFeedProcessor"/>.</returns>
         ChangeFeedProcessor Create<T>(
             Container.ChangesHandler<T> onChanges,
             Container.ChangeFeedMonitorErrorDelegate? onError = null,

--- a/src/Atc.Cosmos/Internal/IChangeFeedListener.cs
+++ b/src/Atc.Cosmos/Internal/IChangeFeedListener.cs
@@ -3,10 +3,24 @@ using System.Threading.Tasks;
 
 namespace Atc.Cosmos.Internal
 {
+    /// <summary>
+    /// Represents a change feed listener and can be used
+    /// to start and stop the listening for changes.
+    /// </summary>
     public interface IChangeFeedListener
     {
+        /// <summary>
+        /// Start listening for changes.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task StartAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Stop listening for changes.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task StopAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Atc.Cosmos/Internal/IChangeFeedListener{T}.cs
+++ b/src/Atc.Cosmos/Internal/IChangeFeedListener{T}.cs
@@ -1,7 +1,0 @@
-namespace Atc.Cosmos.Internal
-{
-    public interface IChangeFeedListener<T> : IChangeFeedListener
-        where T : class, ICosmosResource
-    {
-    }
-}

--- a/src/Atc.Cosmos/Internal/ICosmosClientProvider.cs
+++ b/src/Atc.Cosmos/Internal/ICosmosClientProvider.cs
@@ -1,11 +1,23 @@
-﻿using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos;
 
 namespace Atc.Cosmos.Internal
 {
+    /// <summary>
+    /// Represents a provider for configured
+    /// <see cref="CosmosClient"/> instances.
+    /// </summary>
     public interface ICosmosClientProvider
     {
+        /// <summary>
+        /// Get the default <see cref="CosmosClient"/> instance.
+        /// </summary>
+        /// <returns>A <see cref="CosmosClient"/> instance.</returns>
         CosmosClient GetClient();
 
+        /// <summary>
+        /// Get the <see cref="CosmosClient"/> instance configured for bulk operations.
+        /// </summary>
+        /// <returns><see cref="CosmosClient"/> instance.</returns>
         CosmosClient GetBulkClient();
     }
 }

--- a/src/Atc.Cosmos/Internal/ICosmosContainerNameProvider.cs
+++ b/src/Atc.Cosmos/Internal/ICosmosContainerNameProvider.cs
@@ -2,10 +2,19 @@ using System;
 
 namespace Atc.Cosmos.Internal
 {
+    /// <summary>
+    /// Represents a provider for container names.
+    /// </summary>
     public interface ICosmosContainerNameProvider
     {
-        Type FromType { get; }
-
-        string ContainerName { get; }
+        /// <summary>
+        /// Resolves the configured container name for
+        /// the specified <see cref="ICosmosResource"/> type.
+        /// </summary>
+        /// <param name="resourceType">The <see cref="Type"/>
+        /// of the <see cref="ICosmosResource"/>.</param>
+        /// <returns>A container name.</returns>
+        string? GetContainerName(
+            Type resourceType);
     }
 }

--- a/src/Atc.Cosmos/Internal/ICosmosContainerProvider.cs
+++ b/src/Atc.Cosmos/Internal/ICosmosContainerProvider.cs
@@ -1,14 +1,46 @@
-﻿using Microsoft.Azure.Cosmos;
+using System;
+using Microsoft.Azure.Cosmos;
 
 namespace Atc.Cosmos.Internal
 {
     /// <summary>
-    /// Factory is responsible for providing access to Cosmos DB containers.
+    /// Represents a provider for cosmos <see cref="Container"/> instances.
     /// </summary>
     public interface ICosmosContainerProvider
     {
+        /// <summary>
+        /// Get the configured container for the specified <see cref="ICosmosResource"/> type.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="ICosmosResource"/>.</typeparam>
+        /// <param name="allowBulk">
+        /// Boolean indicating if the container should
+        /// be configured for bulk operations. Default is false.
+        /// </param>
+        /// <returns>A cosmos <see cref="Container"/>.</returns>
         Container GetContainer<T>(bool allowBulk = false);
 
+        /// <summary>
+        /// Get the configured container for the specified <see cref="ICosmosResource"/> type.
+        /// </summary>
+        /// <param name="resourceType">
+        /// The <see cref="Type"/> of the <see cref="ICosmosResource"/>.
+        /// </param>
+        /// <param name="allowBulk">
+        /// Boolean indicating if the container should
+        /// be configured for bulk operations. Default is false.
+        /// </param>
+        /// <returns>A cosmos <see cref="Container"/>.</returns>
+        Container GetContainer(Type resourceType, bool allowBulk = false);
+
+        /// <summary>
+        /// Get the container with a specified name.
+        /// </summary>
+        /// <param name="name">The name of the container.</param>
+        /// <param name="allowBulk">
+        /// Boolean indicating if the container should
+        /// be configured for bulk operations. Default is false.
+        /// </param>
+        /// <returns>A cosmos <see cref="Container"/>.</returns>
         Container GetContainer(string name, bool allowBulk = false);
     }
 }

--- a/src/Atc.Cosmos/Internal/ICosmosInitializer.cs
+++ b/src/Atc.Cosmos/Internal/ICosmosInitializer.cs
@@ -1,10 +1,20 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Atc.Cosmos.Internal
 {
+    /// <summary>
+    /// Represents the initializer responsible for executing
+    /// the configured <see cref="ICosmosContainerInitializer"/>s.
+    /// </summary>
     public interface ICosmosInitializer
     {
+        /// <summary>
+        /// Run the initialization that will execute the
+        /// configured <see cref="ICosmosContainerInitializer"/>s.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task InitializeAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Atc.Cosmos/Testing/FakeCosmosReader.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmosReader.cs
@@ -151,7 +151,7 @@ namespace Atc.Cosmos.Testing
             return Task.FromResult(new PagedResult<TResult>
             {
                 Items = items,
-                ContinuationToken = Invariant($"{startIndex + items.Count}"),
+                ContinuationToken = GetContinuationToken(startIndex, items.Count),
             });
         }
 
@@ -164,6 +164,13 @@ namespace Atc.Cosmos.Testing
                 out var index)
             ? index
             : 0;
+
+        protected static string? GetContinuationToken(
+            int startIndex,
+            int itemsCount)
+            => itemsCount > 0
+             ? Invariant($"{startIndex + itemsCount}")
+             : null;
 
         protected static async IAsyncEnumerable<TItem> GetAsyncEnumerator<TItem>(
             IEnumerable<TItem> items)

--- a/test/Atc.Cosmos.Tests/DependencyInjection/CosmosBuilderTests.cs
+++ b/test/Atc.Cosmos.Tests/DependencyInjection/CosmosBuilderTests.cs
@@ -67,12 +67,10 @@ namespace Atc.Cosmos.Tests.DependencyInjection
                .OfType<ICosmosContainerNameProvider>()
                .Single();
 
-            nameProvider.ContainerName
+            nameProvider
+                .GetContainerName(typeof(Record))
                 .Should()
                 .Be(name);
-            nameProvider.FromType
-                .Should()
-                .Be(typeof(Record));
         }
 
         [Theory, AutoNSubstituteData]
@@ -147,12 +145,10 @@ namespace Atc.Cosmos.Tests.DependencyInjection
                .OfType<ICosmosContainerNameProvider>()
                .Single();
 
-            nameProvider.ContainerName
+            nameProvider
+                .GetContainerName(typeof(Record))
                 .Should()
                 .Be(name);
-            nameProvider.FromType
-                .Should()
-                .Be(typeof(Record));
         }
 
         [Theory, AutoNSubstituteData]

--- a/test/Atc.Cosmos.Tests/DependencyInjection/CosmosContainerBuilderTests.cs
+++ b/test/Atc.Cosmos.Tests/DependencyInjection/CosmosContainerBuilderTests.cs
@@ -37,12 +37,10 @@ namespace Atc.Cosmos.Tests.DependencyInjection
                 .OfType<ICosmosContainerNameProvider>()
                 .Single();
 
-            nameProvider.ContainerName
+            nameProvider
+                .GetContainerName(typeof(Record))
                 .Should()
                 .Be(containerName);
-            nameProvider.FromType
-                .Should()
-                .Be(typeof(Record));
         }
     }
 }

--- a/test/Atc.Cosmos.Tests/Internal/CosmosContainerNameProviderTests.cs
+++ b/test/Atc.Cosmos.Tests/Internal/CosmosContainerNameProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using Atc.Cosmos.Internal;
+using Atc.Cosmos.Internal;
 using Atc.Test;
 using AutoFixture.Xunit2;
 using FluentAssertions;
@@ -9,18 +9,31 @@ namespace Atc.Cosmos.Tests.Internal
     public class CosmosContainerNameProviderTests
     {
         [Theory, AutoNSubstituteData]
-        public void Has_Correct_ContainerName(
+        public void Returns_Correct_ContainerName_For_Type(
             [Frozen] string name,
             CosmosContainerNameProvider<Record> sut)
-            => sut.ContainerName
+            => sut
+                .GetContainerName(typeof(Record))
                 .Should()
                 .Be(name);
 
         [Theory, AutoNSubstituteData]
-        public void Has_Correct_FromType(
+        public void Returns_Null_For_Incorrect_Type(
+            [Frozen] string name,
             CosmosContainerNameProvider<Record> sut)
-            => sut.FromType
+            => sut
+                .GetContainerName(typeof(string))
                 .Should()
-                .Be(typeof(Record));
+                .NotBe(name)
+                .And
+                .BeNull();
+
+        [Theory, AutoNSubstituteData]
+        public void Returns_Correct_ContainerName_For_Generic_Type(
+            string name)
+            => new CosmosContainerNameProvider(typeof(Record<>), name)
+                .GetContainerName(typeof(Record<string>))
+                .Should()
+                .Be(name);
     }
 }

--- a/test/Atc.Cosmos.Tests/Internal/CosmosContainerProviderTests.cs
+++ b/test/Atc.Cosmos.Tests/Internal/CosmosContainerProviderTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Atc.Cosmos.Internal;
 using Atc.Test;
 using AutoFixture.AutoNSubstitute;
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
 using Xunit;
 
 namespace Atc.Cosmos.Tests.Internal
@@ -62,13 +63,9 @@ namespace Atc.Cosmos.Tests.Internal
             cosmosClient
                 .GetContainer(default, default)
                 .ReturnsForAnyArgs(container);
-
             provider
-                .ContainerName
+                .GetContainerName(typeof(string))
                 .Returns(providerName);
-            provider
-                .FromType
-                .Returns(typeof(string));
 
             var sut = new CosmosContainerProvider(clientProvider, options, new[] { provider });
 
@@ -92,18 +89,14 @@ namespace Atc.Cosmos.Tests.Internal
             ICosmosClientProvider clientProvider,
             [Substitute] CosmosClient cosmosClient,
             OptionsWrapper<CosmosOptions> options,
-            [Substitute] ICosmosContainerNameProvider nameProvider,
-            string providerName)
+            [Substitute] ICosmosContainerNameProvider nameProvider)
         {
             clientProvider
                 .GetClient()
                 .Returns(cosmosClient);
             nameProvider
-                .ContainerName
-                .Returns(providerName);
-            nameProvider
-                .FromType
-                .Returns(typeof(string));
+                .GetContainerName(typeof(CosmosContainerProviderTests))
+                .ReturnsNull();
 
             var sut = new CosmosContainerProvider(clientProvider, options, new[] { nameProvider });
             new Action(() => sut.GetContainer<CosmosContainerProviderTests>())
@@ -165,13 +158,9 @@ namespace Atc.Cosmos.Tests.Internal
             cosmosClient
                 .GetContainer(default, default)
                 .ReturnsForAnyArgs(container);
-
             provider
-                .ContainerName
+                .GetContainerName(typeof(string))
                 .Returns(providerName);
-            provider
-                .FromType
-                .Returns(typeof(string));
 
             var sut = new CosmosContainerProvider(clientProvider, options, new[] { provider });
 
@@ -195,18 +184,14 @@ namespace Atc.Cosmos.Tests.Internal
             ICosmosClientProvider clientProvider,
             [Substitute] CosmosClient cosmosClient,
             OptionsWrapper<CosmosOptions> options,
-            [Substitute] ICosmosContainerNameProvider nameProvider,
-            string providerName)
+            [Substitute] ICosmosContainerNameProvider nameProvider)
         {
             clientProvider
                 .GetBulkClient()
                 .Returns(cosmosClient);
             nameProvider
-                .ContainerName
-                .Returns(providerName);
-            nameProvider
-                .FromType
-                .Returns(typeof(string));
+                .GetContainerName(typeof(CosmosContainerProviderTests))
+                .ReturnsNull();
 
             var sut = new CosmosContainerProvider(clientProvider, options, new[] { nameProvider });
             new Action(() => sut.GetContainer<CosmosContainerProviderTests>(allowBulk: true))

--- a/test/Atc.Cosmos.Tests/Record{T}.cs
+++ b/test/Atc.Cosmos.Tests/Record{T}.cs
@@ -1,0 +1,17 @@
+namespace Atc.Cosmos.Tests
+{
+    public sealed class Record<T> : ICosmosResource
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public string Pk { get; set; } = string.Empty;
+
+        public string? ETag { get; set; }
+
+        public T Data { get; set; }
+
+        string ICosmosResource.DocumentId => Id;
+
+        string ICosmosResource.PartitionKey => Pk;
+    }
+}


### PR DESCRIPTION
This PR aims to enable some special cases:
1. Make it possible to use Generic Type Definitions as the resource type for a container, allowing any Generic Type made from the same type definition to be supported in ICosmosReaders and ICosmosWriters.
2. Make it possible to create readers and writers via a factory, if the resource type is not known at at construction time.
3. Add code doc comments and move the `IChangeFeedListener<T>` out of the Internal namespace, to make it more visible. The interface can be used to start and stop change feeds.
4. Address an issue with the `FakeCosmosReader` where `PagedQueryAsync` would return a continuation token even if there were no more results to return.