### PR TITLE
Introduce TryDelete on cosmos writer

### DIFF
--- a/src/Atc.Cosmos/ICosmosWriter.cs
+++ b/src/Atc.Cosmos/ICosmosWriter.cs
@@ -136,6 +136,21 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Tries to delete the specified <typeparamref name="T"/> resource from Cosmos.
+        /// </summary>
+        /// <remarks>
+        /// When trying to delete a non existing resource, False is returned.
+        /// </remarks>
+        /// <param name="documentId">Id of the resource.</param>
+        /// <param name="partitionKey">Partition key of the resource.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>True if resource was deleted otherwise False.</returns>
+        public Task<bool> TryDeleteAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Updates a <typeparamref name="T"/> resource that is read from the configured
         /// Cosmos collection.
         /// </summary>

--- a/src/Atc.Cosmos/Internal/CosmosWriter.cs
+++ b/src/Atc.Cosmos/Internal/CosmosWriter.cs
@@ -108,6 +108,29 @@ namespace Atc.Cosmos.Internal
                     new PartitionKey(partitionKey),
                     cancellationToken: cancellationToken);
 
+        public async Task<bool> TryDeleteAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await container
+                    .DeleteItemAsync<object>(
+                        documentId,
+                        new PartitionKey(partitionKey),
+                        cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (CosmosException ex)
+             when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         public Task<T> UpdateAsync(
             string documentId,
             string partitionKey,

--- a/src/Atc.Cosmos/Testing/FakeCosmos.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmos.cs
@@ -255,6 +255,16 @@ namespace Atc.Cosmos.Testing
                     partitionKey,
                     cancellationToken);
 
+        Task<bool> ICosmosWriter<T>.TryDeleteAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+            => ((ICosmosWriter<T>)Writer)
+                .TryDeleteAsync(
+                    documentId,
+                    partitionKey,
+                    cancellationToken);
+
         Task<T> ICosmosWriter<T>.UpdateAsync(
             string documentId,
             string partitionKey,

--- a/src/Atc.Cosmos/Testing/FakeCosmosWriter.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmosWriter.cs
@@ -125,6 +125,28 @@ namespace Atc.Cosmos.Testing
             return Task.CompletedTask;
         }
 
+        public async Task<bool> TryDeleteAsync(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                await DeleteAsync(
+                    documentId,
+                    partitionKey,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            }
+            catch (CosmosException ex)
+             when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
         public virtual Task<T> UpdateAsync(
             string documentId,
             string partitionKey,


### PR DESCRIPTION
This PR introduces the ability to try and delete a resource without the requirements to handle `CosmosException` with status code `NotFound`. Instead the new method will return `true` when the record is deleted otherwise `false`.