### PR TITLE
Feature/token credential support

### DIFF
--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           setAllVars: true
 
-      - name: ⚙️ Setup dotnet 5.0.x
+      - name: ⚙️ Setup dotnet 6.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: ⚙️ Set up JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: ⚙️ Setup dotnet 5.0.x
+      - name: ⚙️ Setup dotnet 6.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: 🧹 Clean
         run: dotnet clean -c Release && dotnet nuget locals all --clear
@@ -43,10 +43,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: ⚙️ Setup dotnet 5.0.x
+      - name: ⚙️ Setup dotnet 6.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: 🔁 Restore packages
         run: dotnet restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
         with:
           setAllVars: true
 
-      - name: ⚙️ Setup dotnet 5.0.x
+      - name: ⚙️ Setup dotnet 6.0.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: 🧹 Clean
         run: dotnet clean -c Release && dotnet nuget locals all --clear

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,11 +41,10 @@
   <ItemGroup Label="Code Analyzers">
     <PackageReference Include="AsyncFixer" Version="1.5.1" PrivateAssets="All" />
     <PackageReference Include="Asyncify" Version="0.9.7" PrivateAssets="all" />
-    <PackageReference Include="Meziantou.Analyzer" Version="1.0.661" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="All" />
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.1.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.2" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.22.0.31243" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.36.1.44192" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ For configuring how the library connects to Cosmos, the library uses the `Cosmos
 | `DatabaseName` | Name of the Cosmos database (will be provisioned by the library). |
 | `DatabaseThroughput` | The throughput provisioned for the database in measurement of Request Units per second in the Azure Cosmos DB service. |
 | `SerializerOptions` | The `JsonSerializerOptions` used for the `System.Text.Json.JsonSerializer`. |
+| `Credential` | The `TokenCredential` used for accessing [cosmos with an Azure AD token](https://docs.microsoft.com/en-us/azure/cosmos-db/managed-identity-based-authentication). Please note that setting this property will ignore any value specified in `AccountKey`. |
 
 <br/>
 

--- a/src/Atc.Cosmos/Atc.Cosmos.csproj
+++ b/src/Atc.Cosmos/Atc.Cosmos.csproj
@@ -8,18 +8,18 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.17" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.25.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
-    <PackageReference Include="Nullable" Version="1.2.1">
+    <PackageReference Include="Nullable" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
 </Project>

--- a/src/Atc.Cosmos/CosmosOptions.cs
+++ b/src/Atc.Cosmos/CosmosOptions.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Azure.Core;
 
 namespace Atc.Cosmos
 {
@@ -25,8 +26,9 @@ namespace Atc.Cosmos
         /// Navigate to your Azure Cosmos account.
         /// Open the Connection Strings or Keys pane, and copy the
         /// "Password" or PRIMARY KEY value.
+        /// The <see cref="AccountKey"/> is required if <see cref="Credential"/> is not specified.
         /// </remarks>
-        public string AccountKey { get; set; } = default!;
+        public string? AccountKey { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the Cosmos database name.
@@ -57,5 +59,13 @@ namespace Atc.Cosmos
         /// </summary>
         public JsonSerializerOptions SerializerOptions { get; set; }
             = new JsonSerializerOptions();
+
+        /// <summary>
+        /// Gets or sets the TokenCredential to use instead of <see cref="AccountKey"/>.
+        /// </summary>
+        /// <remarks>
+        /// When <see cref="TokenCredential"/> is provided the property <see cref="AccountKey"/> is not needed.
+        /// </remarks>
+        public TokenCredential? Credential { get; set; }
     }
 }

--- a/src/Atc.Cosmos/Internal/CosmosClientProvider.cs
+++ b/src/Atc.Cosmos/Internal/CosmosClientProvider.cs
@@ -45,7 +45,7 @@ namespace Atc.Cosmos.Internal
         private static bool IsValid(CosmosOptions? options)
             => options is not null
             && !string.IsNullOrEmpty(options.AccountEndpoint)
-            && !string.IsNullOrEmpty(options.AccountKey)
+            && (!string.IsNullOrEmpty(options.AccountKey) || options.Credential is not null)
             && !string.IsNullOrEmpty(options.DatabaseName);
 
         private CosmosClient CreateClient(bool allowBulk)
@@ -59,7 +59,12 @@ namespace Atc.Cosmos.Internal
             options.Serializer = cosmosClientOptions.Value.Serializer
                 ?? new CosmosSerializerAdapter(serializer);
 
-            return new CosmosClient(connectionString, options);
+            return cosmosOptions.Value.Credential is not null
+                 ? new CosmosClient(
+                     cosmosOptions.Value.AccountEndpoint,
+                     cosmosOptions.Value.Credential,
+                     options)
+                 : new CosmosClient(connectionString, options);
         }
 
         private CosmosClientOptions CreateCosmosClientOptions()

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -54,8 +54,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.194" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/test/Atc.Cosmos.Tests/Atc.Cosmos.Tests.csproj
+++ b/test/Atc.Cosmos.Tests/Atc.Cosmos.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Atc.Test" Version="1.0.58" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Atc.Cosmos.Tests/Atc.Cosmos.Tests.csproj
+++ b/test/Atc.Cosmos.Tests/Atc.Cosmos.Tests.csproj
@@ -1,25 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
-    <PackageReference Include="Atc.Test" Version="1.0.31" />
+    <PackageReference Include="Atc.Test" Version="1.0.58" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.17.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="NSubstitute" Version="4.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="NSubstitute" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Atc.Cosmos.Tests/CosmosBulkReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosBulkReaderTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Atc.Cosmos.Internal;
@@ -117,7 +117,7 @@ namespace Atc.Cosmos.Tests
             FluentActions
                 .Awaiting(() => sut.ReadAsync(documentId, partitionKey, cancellationToken))
                 .Should()
-                .Throw<CosmosException>();
+                .ThrowAsync<CosmosException>();
         }
 
         [Theory, AutoNSubstituteData]

--- a/test/Atc.Cosmos.Tests/CosmosOptionsExtensionsTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosOptionsExtensionsTests.cs
@@ -1,4 +1,4 @@
-using AutoFixture.Xunit2;
+using Atc.Test;
 using FluentAssertions;
 using Xunit;
 using SUT = Atc.Cosmos.CosmosOptionsExtensions;
@@ -7,7 +7,7 @@ namespace Atc.Cosmos.Tests
 {
     public class CosmosOptionsExtensionsTests
     {
-        [Theory, AutoData]
+        [Theory, AutoNSubstituteData]
         public void UseCosmosEmulator_Sets_AccountEndpoint(
             CosmosOptions options)
         {
@@ -18,7 +18,7 @@ namespace Atc.Cosmos.Tests
                 .Be("https://localhost:8081");
         }
 
-        [Theory, AutoData]
+        [Theory, AutoNSubstituteData]
         public void UseCosmosEmulator_Sets_AccountKey(
             CosmosOptions options)
         {

--- a/test/Atc.Cosmos.Tests/CosmosReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosReaderTests.cs
@@ -123,7 +123,7 @@ namespace Atc.Cosmos.Tests
             FluentActions
                 .Awaiting(() => sut.ReadAsync(documentId, partitionKey, cancellationToken))
                 .Should()
-                .Throw<CosmosException>();
+                .ThrowAsync<CosmosException>();
         }
 
         [Theory, AutoNSubstituteData]

--- a/test/Atc.Cosmos.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/test/Atc.Cosmos.Tests/DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -2,6 +2,7 @@ using System;
 using Atc.Cosmos.DependencyInjection;
 using Atc.Cosmos.Internal;
 using Atc.Cosmos.Serialization;
+using Atc.Test;
 using AutoFixture;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -21,7 +22,8 @@ namespace Atc.Cosmos.Tests.DependencyInjection
 
         public ServiceCollectionExtensionsTests()
         {
-            var cosmosOptions = new Fixture().Create<CosmosOptions>();
+            var fixture = FixtureFactory.Create();
+            var cosmosOptions = fixture.Create<CosmosOptions>();
             cosmosOptions.UseCosmosEmulator();
             options = Options.Create(cosmosOptions);
             services = Substitute.For<IServiceCollection>();

--- a/test/Atc.Cosmos.Tests/Generators/FakeTokenCredential.cs
+++ b/test/Atc.Cosmos.Tests/Generators/FakeTokenCredential.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+
+namespace Atc.Cosmos.Tests.Generators
+{
+    internal class FakeTokenCredential : TokenCredential
+    {
+        private readonly AccessToken accessToken = new (
+            "token",
+            DateTimeOffset.UtcNow.AddDays(10));
+
+        public override AccessToken GetToken(
+            TokenRequestContext requestContext,
+            CancellationToken cancellationToken)
+            => accessToken;
+
+        public override ValueTask<AccessToken> GetTokenAsync(
+            TokenRequestContext requestContext,
+            CancellationToken cancellationToken)
+            => ValueTask.FromResult(accessToken);
+    }
+}

--- a/test/Atc.Cosmos.Tests/Generators/TokenCredentialGenerator.cs
+++ b/test/Atc.Cosmos.Tests/Generators/TokenCredentialGenerator.cs
@@ -1,0 +1,15 @@
+using Atc.Test.Customizations;
+using AutoFixture.Kernel;
+using Azure.Core;
+
+namespace Atc.Cosmos.Tests.Generators
+{
+    [AutoRegister]
+    public class TokenCredentialGenerator : TypeRelay
+    {
+        public TokenCredentialGenerator()
+            : base(typeof(TokenCredential), typeof(FakeTokenCredential))
+        {
+        }
+    }
+}

--- a/test/Atc.Cosmos.Tests/Internal/CosmosClientProviderTests.cs
+++ b/test/Atc.Cosmos.Tests/Internal/CosmosClientProviderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using Atc.Cosmos.Internal;
 using Atc.Cosmos.Serialization;
+using Atc.Cosmos.Tests.Generators;
 using Atc.Test;
 using AutoFixture;
 using AutoFixture.AutoNSubstitute;
@@ -174,6 +175,67 @@ namespace Atc.Cosmos.Tests.Internal
                 .Serializer
                 .Should()
                 .Be(serializer);
+        }
+
+        [Fact]
+        public void Client_Should_Use_TokenCredential_When_Specified()
+        {
+            cosmosOptions.Credential = new FakeTokenCredential();
+            using var provider = new CosmosClientProvider(
+                Options.Create(cosmosOptions),
+                Options.Create(cosmosClientOptions),
+                serializer);
+
+            // As there is not possiblility to assert if a CosmosClient
+            // has been instanciated with a TokenCredential or auth key
+            // we simply ensure that we get a client object.
+            provider
+                .GetClient()
+                .Should()
+                .NotBeNull();
+        }
+
+        [Fact]
+        public void ShouldThrow_When_TokenCredential_And_AccountKey_IsMissing()
+        {
+            cosmosOptions.Credential = null;
+            cosmosOptions.AccountKey = string.Empty;
+
+            FluentActions.Invoking(
+                () => new CosmosClientProvider(
+                    Options.Create(cosmosOptions),
+                    Options.Create(cosmosClientOptions),
+                    serializer))
+                .Should()
+                .Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void ShouldThrow_When_No_AccountEndpoint_IsConfigured()
+        {
+            cosmosOptions.AccountEndpoint = string.Empty;
+
+            FluentActions.Invoking(
+                () => new CosmosClientProvider(
+                    Options.Create(cosmosOptions),
+                    Options.Create(cosmosClientOptions),
+                    serializer))
+                .Should()
+                .Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void ShouldThrow_When_No_DatabaseName_IsConfigured()
+        {
+            cosmosOptions.DatabaseName = string.Empty;
+
+            FluentActions.Invoking(
+                () => new CosmosClientProvider(
+                    Options.Create(cosmosOptions),
+                    Options.Create(cosmosClientOptions),
+                    serializer))
+                .Should()
+                .Throw<InvalidOperationException>();
         }
     }
 }

--- a/test/Atc.Cosmos.Tests/Internal/CosmosInitializerTests.cs
+++ b/test/Atc.Cosmos.Tests/Internal/CosmosInitializerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -95,7 +95,7 @@ namespace Atc.Cosmos.Tests.Internal
             var sut = new CosmosInitializer(clientProvider, options, new[] { initializer });
             new Func<Task>(() => sut.InitializeAsync(cancellationToken))
                 .Should()
-                .ThrowExactly<InvalidOperationException>()
+                .ThrowExactlyAsync<InvalidOperationException>()
                 .WithMessage("Please start Cosmos DB Emulator");
         }
 
@@ -113,7 +113,7 @@ namespace Atc.Cosmos.Tests.Internal
             var sut = new CosmosInitializer(clientProvider, options, new[] { initializer });
             new Func<Task>(() => sut.InitializeAsync(cancellationToken))
                 .Should()
-                .ThrowExactly<InvalidOperationException>()
+                .ThrowExactlyAsync<InvalidOperationException>()
                 .WithMessage("Please start Cosmos DB Emulator");
         }
 
@@ -134,7 +134,7 @@ namespace Atc.Cosmos.Tests.Internal
             var sut = new CosmosInitializer(clientProvider, options, new[] { initializer });
             new Func<Task>(() => sut.InitializeAsync(cancellationToken))
                 .Should()
-                .ThrowExactly<InvalidOperationException>()
+                .ThrowExactlyAsync<InvalidOperationException>()
                 .WithMessage("Please start Cosmos DB Emulator");
         }
 
@@ -152,7 +152,7 @@ namespace Atc.Cosmos.Tests.Internal
             var sut = new CosmosInitializer(clientProvider, options, new[] { initializer });
             new Func<Task>(() => sut.InitializeAsync(cancellationToken))
                 .Should()
-                .ThrowExactly<Exception>()
+                .ThrowExactlyAsync<Exception>()
                 .Where(e => e == exception);
         }
 
@@ -170,7 +170,7 @@ namespace Atc.Cosmos.Tests.Internal
             var sut = new CosmosInitializer(clientProvider, options, new[] { initializer });
             new Func<Task>(() => sut.InitializeAsync(cancellationToken))
                 .Should()
-                .ThrowExactly<Exception>()
+                .ThrowExactlyAsync<Exception>()
                 .Where(e => e == exception);
         }
     }

--- a/test/Atc.Cosmos.Tests/Testing/FakeCosmosReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/Testing/FakeCosmosReaderTests.cs
@@ -69,7 +69,7 @@ namespace Atc.Cosmos.Tests.Testing
         {
             FluentActions.Awaiting(() => sut.ReadAsync(documentId, partitionKey))
                 .Should()
-                .Throw<CosmosException>()
+                .ThrowAsync<CosmosException>()
                 .Where(e => e.StatusCode == System.Net.HttpStatusCode.NotFound);
         }
 
@@ -187,10 +187,10 @@ namespace Atc.Cosmos.Tests.Testing
 
             page1.Items
                 .Should()
-                .BeEquivalentTo(queryResults[0]);
+                .BeEquivalentTo(new[] { queryResults[0] });
             page2.Items
                 .Should()
-                .BeEquivalentTo(queryResults[1]);
+                .BeEquivalentTo(new[] { queryResults[1] });
         }
 
         [Theory, AutoNSubstituteData]
@@ -217,10 +217,10 @@ namespace Atc.Cosmos.Tests.Testing
 
             page1.Items
                 .Should()
-                .BeEquivalentTo(queryResults[0]);
+                .BeEquivalentTo(new[] { queryResults[0] });
             page2.Items
                 .Should()
-                .BeEquivalentTo(queryResults[1]);
+                .BeEquivalentTo(new[] { queryResults[1] });
         }
 
         [Theory, AutoNSubstituteData]

--- a/test/Atc.Cosmos.Tests/Testing/FakeCosmosWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/Testing/FakeCosmosWriterTests.cs
@@ -49,7 +49,7 @@ namespace Atc.Cosmos.Tests.Testing
             sut.Documents.Add(record);
             FluentActions.Awaiting(() => sut.CreateAsync(record))
                 .Should()
-                .Throw<CosmosException>()
+                .ThrowAsync<CosmosException>()
                 .Where(e => e.StatusCode == System.Net.HttpStatusCode.Conflict);
         }
 
@@ -114,7 +114,7 @@ namespace Atc.Cosmos.Tests.Testing
         {
             FluentActions.Awaiting(() => sut.ReplaceAsync(record))
                 .Should()
-                .Throw<CosmosException>()
+                .ThrowAsync<CosmosException>()
                 .Where(e => e.StatusCode == System.Net.HttpStatusCode.NotFound);
         }
 
@@ -160,7 +160,7 @@ namespace Atc.Cosmos.Tests.Testing
 
             FluentActions.Awaiting(() => sut.ReplaceAsync(record))
                 .Should()
-                .Throw<CosmosException>()
+                .ThrowAsync<CosmosException>()
                 .Where(e => e.StatusCode == System.Net.HttpStatusCode.PreconditionFailed);
         }
 
@@ -190,7 +190,7 @@ namespace Atc.Cosmos.Tests.Testing
         {
             FluentActions.Awaiting(() => sut.DeleteAsync(documentId, partitionKey))
                 .Should()
-                .Throw<CosmosException>()
+                .ThrowAsync<CosmosException>()
                 .Where(e => e.StatusCode == System.Net.HttpStatusCode.NotFound);
         }
 
@@ -224,7 +224,7 @@ namespace Atc.Cosmos.Tests.Testing
                     partitionKey,
                     d => { }))
                 .Should()
-                .Throw<CosmosException>()
+                .ThrowAsync<CosmosException>()
                 .Where(e => e.StatusCode == System.Net.HttpStatusCode.NotFound);
         }
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Test Analyzers">
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.14" PrivateAssets="All" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR introduces the options to specify a token credential provider instead of an `AccountKey`.
This will enable scenarios where database and containers is only allowed to be accessed using Azure AD identity such as Managed Service Identity.

As part of this change the `AccountKey` on `CosmosOptions` is made optional (nullable) and is only used when `Credential` is not specified (null).