### PR TITLE
fix: removed sealed keyword from FakeCosmos

### DIFF
--- a/src/Atc.Cosmos/Testing/FakeCosmos.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmos.cs
@@ -9,6 +9,10 @@ using Microsoft.Azure.Cosmos;
 namespace Atc.Cosmos.Testing
 {
     [SuppressMessage(
+        "Design",
+        "CA1033:Interface methods should be callable by child types",
+        Justification = "By design")]
+    [SuppressMessage(
        "Design",
        "MA0016:Prefer return collection abstraction instead of implementation",
        Justification = "By design")]

--- a/src/Atc.Cosmos/Testing/FakeCosmos.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmos.cs
@@ -20,7 +20,7 @@ namespace Atc.Cosmos.Testing
        "Usage",
        "CA2227:Collection properties should be read only",
        Justification = "By design")]
-    public sealed class FakeCosmos<T> :
+    public class FakeCosmos<T> :
         ICosmosReader<T>,
         ICosmosWriter<T>,
         ICosmosBulkReader<T>,


### PR DESCRIPTION
Removing the `sealed` keyword makes it possible to create specialized versions, that implement custom interfaces.

For example:

If we have the following types:

1. `public class Group : CosmosResource` type.
2. `IGroupReader : ICosmosReader<Group>` that contain additional methods that simplify querying a Cosmos container, e.g. 

```c#
public interface IGroupReader : ICosmosReader<Group>
{
    public Task<Group?> FindByIdAsync(string groupId, CancellationToken cancellationToken)
        => FindAsync(groupId, Names.GroupPartitionKey, cancellationToken);
}
```

3. A system under test, `CanHazGroup` that uses `IGroupReader`

Then we're able to create a custom fake to use with AutoFixture and NSubsitute:

```c#
public class FakeGroupCosmos : FakeCosmos<Group>, IGroupReader { }
```

Like so:

```c#
[Theory, AutoNSubstituteData]
internal async Task RetrieveGroupById_with_existing_groupId(
    [Frozen(Matching.ImplementedInterfaces)] FakeGroupCosmos cosmos,
    CosmosGroupRepository sut,
    Group group)
{
    cosmos.Documents.Add(group);

    //...
}
```

Using interfaces like `IGroupReader` instead of directly `ICosmosReader` allows me to keep details like partition keys internal to the library that implements cosmos access.