### PR TITLE
Introduce methods for reading all data across partitions

### DIFF
--- a/src/Atc.Cosmos/ICosmosBulkReader.cs
+++ b/src/Atc.Cosmos/ICosmosBulkReader.cs
@@ -59,6 +59,14 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Reads all the specified <typeparamref name="T"/> resource from the configured
+        /// Cosmos collection.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over all the <typeparamref name="T"/> resources.</returns>
+        public IAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Query documents from the configured Cosmos container.
         /// </summary>
         /// <param name="query">Cosmos query to execute.</param>

--- a/src/Atc.Cosmos/ICosmosBulkReader.cs
+++ b/src/Atc.Cosmos/ICosmosBulkReader.cs
@@ -61,6 +61,9 @@ namespace Atc.Cosmos
         /// <summary>
         /// Reads all the specified <typeparamref name="T"/> resource from the configured
         /// Cosmos collection.
+        ///
+        /// It is NOT recommended to read data across partitions.
+        /// This method is provided for convenience for scenarios where ALL data needs to processed or re-processed.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
         /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over all the <typeparamref name="T"/> resources.</returns>

--- a/src/Atc.Cosmos/ICosmosReader.cs
+++ b/src/Atc.Cosmos/ICosmosReader.cs
@@ -61,6 +61,9 @@ namespace Atc.Cosmos
         /// <summary>
         /// Reads all the specified <typeparamref name="T"/> resource from the configured
         /// Cosmos collection.
+        ///
+        /// It is NOT recommended to read data across partitions.
+        /// This method is provided for convenience for scenarios where ALL data needs to processed or re-processed.
         /// </summary>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
         /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over all the <typeparamref name="T"/> resources.</returns>

--- a/src/Atc.Cosmos/ICosmosReader.cs
+++ b/src/Atc.Cosmos/ICosmosReader.cs
@@ -59,6 +59,15 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Reads all the specified <typeparamref name="T"/> resource from the configured
+        /// Cosmos collection.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over all the <typeparamref name="T"/> resources.</returns>
+        public IAsyncEnumerable<T> ReadAllAsync(
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Query documents from the configured Cosmos container.
         /// </summary>
         /// <param name="query">Cosmos query to execute.</param>

--- a/src/Atc.Cosmos/Internal/CosmosBulkReader.cs
+++ b/src/Atc.Cosmos/Internal/CosmosBulkReader.cs
@@ -75,6 +75,23 @@ namespace Atc.Cosmos.Internal
             }
         }
 
+        public async IAsyncEnumerable<T> ReadAllAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var reader = container.GetItemQueryIterator<T>(ReadAllQuery);
+
+            while (reader.HasMoreResults && !cancellationToken.IsCancellationRequested)
+            {
+                var documents = await reader
+                    .ReadNextAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                foreach (var document in documents)
+                {
+                    yield return document;
+                }
+            }
+        }
+
         public IAsyncEnumerable<T> QueryAsync(
             QueryDefinition query,
             string partitionKey,

--- a/src/Atc.Cosmos/Internal/CosmosReader.cs
+++ b/src/Atc.Cosmos/Internal/CosmosReader.cs
@@ -81,6 +81,24 @@ namespace Atc.Cosmos.Internal
             }
         }
 
+        public async IAsyncEnumerable<T> ReadAllAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            var reader = container.GetItemQueryIterator<T>(ReadAllQuery);
+
+            while (reader.HasMoreResults && !cancellationToken.IsCancellationRequested)
+            {
+                var documents = await reader
+                    .ReadNextAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                foreach (var document in documents)
+                {
+                    yield return document;
+                }
+            }
+        }
+
         public IAsyncEnumerable<T> QueryAsync(
             QueryDefinition query,
             string partitionKey,

--- a/src/Atc.Cosmos/Testing/FakeCosmos.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmos.cs
@@ -101,6 +101,11 @@ namespace Atc.Cosmos.Testing
                     partitionKey,
                     cancellationToken);
 
+        IAsyncEnumerable<T> ICosmosReader<T>.ReadAllAsync(
+            CancellationToken cancellationToken)
+            => ((ICosmosReader<T>)Reader)
+                .ReadAllAsync(cancellationToken);
+
         IAsyncEnumerable<T> ICosmosReader<T>.QueryAsync(
             QueryDefinition query,
             string partitionKey,

--- a/src/Atc.Cosmos/Testing/FakeCosmos.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmos.cs
@@ -182,6 +182,11 @@ namespace Atc.Cosmos.Testing
                     partitionKey,
                     cancellationToken);
 
+        IAsyncEnumerable<T> ICosmosBulkReader<T>.ReadAllAsync(
+            CancellationToken cancellationToken)
+            => ((ICosmosBulkReader<T>)Reader)
+                .ReadAllAsync(cancellationToken);
+
         IAsyncEnumerable<T> ICosmosBulkReader<T>.QueryAsync(
             QueryDefinition query,
             string partitionKey,

--- a/src/Atc.Cosmos/Testing/FakeCosmosReader.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmosReader.cs
@@ -103,6 +103,10 @@ namespace Atc.Cosmos.Testing
                 .Where(d => d.PartitionKey == partitionKey)
                 .Clone(options));
 
+        public IAsyncEnumerable<T> ReadAllAsync(
+            CancellationToken cancellationToken = default)
+            => GetAsyncEnumerator(Documents.Clone(options));
+
         public virtual IAsyncEnumerable<T> QueryAsync(
             QueryDefinition query,
             string partitionKey,


### PR DESCRIPTION
I stumble upon a scenario every now and then where I need to re-process ALL data in a given container for things like data migration or for publishing to an EventHub

The changes here introduces the the ReadAllAsync() overload in `ICosmosReader` and `ICosmosBulkReader`

```csharp
/// <summary>
/// Reads all the specified <typeparamref name="T"/> resource from the configured
/// Cosmos collection.
///
/// It is NOT recommended to read data across partitions.
/// This method is provided for convenience for scenarios where ALL data needs to processed or re-processed.
/// </summary>
/// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
/// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over all the <typeparamref name="T"/> resources.</returns>
public IAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken = default);
```