### PR TITLE
Update PR verification to build and test against .NET 6.0 and 7.0

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -24,8 +24,8 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            '6.0.x'
-            '7.0.x'
+            6.0.x
+            7.0.x
 
       - name: 🧹 Clean
         run: dotnet clean -c Release && dotnet nuget locals all --clear
@@ -54,8 +54,8 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            '6.0.x'
-            '7.0.x'
+            6.0.x
+            7.0.x
 
       - name: 🔁 Restore packages
         run: dotnet restore

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        dotnet_version: ['6.0.x', '7.0.x']
+        runtime: ['net6.0', 'net7.0']
     runs-on: ${{ matrix.os }}
     steps:
       - name: 🛒 Checkout repository
@@ -20,10 +20,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: ⚙️ Setup dotnet ${{ matrix.dotnet_version }}
-        uses: actions/setup-dotnet@v1
+      - name: ⚙️ Setup dotnet
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ matrix.dotnet_version }}
+          dotnet-version: |
+            '6.0.x', 
+            '7.0.x'
 
       - name: 🧹 Clean
         run: dotnet clean -c Release && dotnet nuget locals all --clear
@@ -32,13 +34,13 @@ jobs:
         run: dotnet restore
 
       - name: 🛠️ Building library in release mode
-        run: dotnet build -c Release --no-restore
+        run: dotnet build -c Release --no-restore --runtime ${{ matrix.runtime }}
 
   dotnet-test:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        dotnet_version: ['6.0.x', '7.0.x']
+        runtime: ['net6.0', 'net7.0']
     runs-on: ${{ matrix.os }}
     needs:
       - dotnet-build
@@ -48,16 +50,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: ⚙️ Setup dotnet ${{ matrix.dotnet_version }}
-        uses: actions/setup-dotnet@v1
+      - name: ⚙️ Setup dotnet
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: ${{ matrix.dotnet_version }}
+          dotnet-version: |
+            '6.0.x', 
+            '7.0.x'
 
       - name: 🔁 Restore packages
         run: dotnet restore
 
       - name: 🛠️ Build
-        run: dotnet build -c Release --no-restore /p:UseSourceLink=true
+        run: dotnet build -c Release --no-restore /p:UseSourceLink=true --runtime ${{ matrix.runtime }}
 
       - name: 🧪 Run unit tests
-        run: dotnet test -c Release --no-build
+        run: dotnet test -c Release --no-build --runtime ${{ matrix.runtime }}

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            '6.0.x', 
+            '6.0.x'
             '7.0.x'
 
       - name: 🧹 Clean
@@ -54,7 +54,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            '6.0.x', 
+            '6.0.x'
             '7.0.x'
 
       - name: 🔁 Restore packages

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: ⚙️ Setup dotnet ${{ matrix.os }}
+      - name: ⚙️ Setup dotnet ${{ matrix.dotnet_version }}
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ matrix.os }}
+          dotnet-version: ${{ matrix.dotnet_version }}
 
       - name: 🧹 Clean
         run: dotnet clean -c Release && dotnet nuget locals all --clear
@@ -48,10 +48,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: ⚙️ Setup dotnet ${{ matrix.os }}
+      - name: ⚙️ Setup dotnet ${{ matrix.dotnet_version }}
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: ${{ matrix.os }}
+          dotnet-version: ${{ matrix.dotnet_version }}
 
       - name: 🔁 Restore packages
         run: dotnet restore

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -8,10 +8,11 @@ on:
       - reopened
 
 jobs:
-  dotnet5-build:
+  dotnet-build:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        dotnet_version: ['6.0.x', '7.0.x']
     runs-on: ${{ matrix.os }}
     steps:
       - name: 🛒 Checkout repository
@@ -19,10 +20,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: ⚙️ Setup dotnet 6.0.x
+      - name: ⚙️ Setup dotnet ${{ matrix.os }}
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: ${{ matrix.os }}
 
       - name: 🧹 Clean
         run: dotnet clean -c Release && dotnet nuget locals all --clear
@@ -34,19 +35,23 @@ jobs:
         run: dotnet build -c Release --no-restore
 
   dotnet-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        dotnet_version: ['6.0.x', '7.0.x']
+    runs-on: ${{ matrix.os }}
     needs:
-      - dotnet5-build
+      - dotnet-build
     steps:
       - name: 🛒 Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: ⚙️ Setup dotnet 6.0.x
+      - name: ⚙️ Setup dotnet ${{ matrix.os }}
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: ${{ matrix.os }}
 
       - name: 🔁 Restore packages
         run: dotnet restore

--- a/test/Atc.Cosmos.Tests/Atc.Cosmos.Tests.csproj
+++ b/test/Atc.Cosmos.Tests/Atc.Cosmos.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
The changes here keeps the PR build verification workflow up-to-date with the latest .NET version