### PR TITLE
Fixed AddContainer to use IScopedCosmosContainerInitializer

### DIFF
--- a/src/Atc.Cosmos/DependencyInjection/CosmosBuilder.cs
+++ b/src/Atc.Cosmos/DependencyInjection/CosmosBuilder.cs
@@ -37,7 +37,11 @@ namespace Atc.Cosmos.DependencyInjection
             Action<ICosmosContainerBuilder> builder)
             where TInitializer : class, ICosmosContainerInitializer
         {
-            Services.AddSingleton<ICosmosContainerInitializer, TInitializer>();
+            Services.AddSingleton<TInitializer>();
+            Services.AddSingleton<IScopedCosmosContainerInitializer>(
+                s => new ScopedCosmosContainerInitializer(
+                    Options,
+                    s.GetRequiredService<TInitializer>()));
 
             return AddContainer(name, builder);
         }

--- a/test/Atc.Cosmos.Tests/DependencyInjection/CosmosBuilderTests.cs
+++ b/test/Atc.Cosmos.Tests/DependencyInjection/CosmosBuilderTests.cs
@@ -74,8 +74,12 @@ namespace Atc.Cosmos.Tests.DependencyInjection
             services
                 .Received(1)
                 .Add(Arg.Is<ServiceDescriptor>(s
-                    => s.ServiceType == typeof(ICosmosContainerInitializer)
+                    => s.ServiceType == typeof(RecordInitializer)
                     && s.ImplementationType == typeof(RecordInitializer)));
+            services
+                .Received(1)
+                .Add(Arg.Is<ServiceDescriptor>(s
+                    => s.ServiceType == typeof(IScopedCosmosContainerInitializer)));
         }
 
         [Theory, AutoNSubstituteData]


### PR DESCRIPTION
Fixed AddContainer with initializer to register initializer wrapped in IScopedCosmosContainerInitializer as is done with all other initializers.