### PR TITLE
Add LINQ-based query overloads

### DIFF
--- a/src/Atc.Cosmos/ICosmosReader.cs
+++ b/src/Atc.Cosmos/ICosmosReader.cs
@@ -132,6 +132,23 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Query documents from the configured Cosmos container using pagination and a custom result.
+        /// </summary>
+        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
+        /// <param name="partitionKey">Partition key of the resource.</param>
+        /// <param name="pageSize">The number of items to return per page.</param>
+        /// <param name="continuationToken">The continuationToken for getting the next page of a previous query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <typeparamref name="TResult"/> containing the custom query result.</returns>
+        public Task<PagedResult<TResult>> PagedQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            string partitionKey,
+            int? pageSize,
+            string? continuationToken = default,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Query documents across partitions from the configured Cosmos container.
         /// </summary>
         /// <param name="query">Cosmos query to execute.</param>
@@ -150,6 +167,17 @@ namespace Atc.Cosmos
         /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="TResult"/> resources.</returns>
         public IAsyncEnumerable<TResult> CrossPartitionQueryAsync<TResult>(
             QueryDefinition query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Query documents across partitions from the configured Cosmos container and returns a custom result.
+        /// </summary>
+        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="TResult"/> resources.</returns>
+        public IAsyncEnumerable<TResult> CrossPartitionQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -177,6 +205,21 @@ namespace Atc.Cosmos
         /// <returns>A <typeparamref name="TResult"/> containing the custom query result.</returns>
         public Task<PagedResult<TResult>> CrossPartitionPagedQueryAsync<TResult>(
             QueryDefinition query,
+            int? pageSize,
+            string? continuationToken = default,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Query documents across partitions from the configured Cosmos container using pagination and a custom result.
+        /// </summary>
+        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
+        /// <param name="pageSize">The number of items to return per page.</param>
+        /// <param name="continuationToken">The continuationToken for getting the next page of a previous query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>A <typeparamref name="TResult"/> containing the custom query result.</returns>
+        public Task<PagedResult<TResult>> CrossPartitionPagedQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
             int? pageSize,
             string? continuationToken = default,
             CancellationToken cancellationToken = default);
@@ -218,6 +261,19 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Query documents from the configured Cosmos container and returns a custom result.
+        /// </summary>
+        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
+        /// <param name="partitionKey">Partition key of the resource.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="TResult"/> resources.</returns>
+        public IAsyncEnumerable<IEnumerable<TResult>> BatchQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            string partitionKey,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Query documents across partitions from the configured Cosmos container.
         /// </summary>
         /// <param name="query">Cosmos query to execute.</param>
@@ -236,6 +292,17 @@ namespace Atc.Cosmos
         /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="TResult"/> resources.</returns>
         public IAsyncEnumerable<IEnumerable<TResult>> BatchCrossPartitionQueryAsync<TResult>(
             QueryDefinition query,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Query documents across partitions from the configured Cosmos container and returns a custom result.
+        /// </summary>
+        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="TResult"/> resources.</returns>
+        public IAsyncEnumerable<IEnumerable<TResult>> BatchCrossPartitionQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/Atc.Cosmos/ICosmosReader.cs
+++ b/src/Atc.Cosmos/ICosmosReader.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -80,6 +82,19 @@ namespace Atc.Cosmos
         /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="TResult"/> resources.</returns>
         public IAsyncEnumerable<TResult> QueryAsync<TResult>(
             QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Query documents from the configured Cosmos container using IQueryable.
+        /// </summary>
+        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
+        /// <param name="partitionKey">Partition key of the resource.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
+        /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="T"/> resources.</returns>
+        public IAsyncEnumerable<TResult> QueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
             string partitionKey,
             CancellationToken cancellationToken = default);
 

--- a/src/Atc.Cosmos/ICosmosReader.cs
+++ b/src/Atc.Cosmos/ICosmosReader.cs
@@ -88,7 +88,7 @@ namespace Atc.Cosmos
         /// <summary>
         /// Query documents from the configured Cosmos container using IQueryable.
         /// </summary>
-        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <typeparam name="TResult">The type of the query result.</typeparam>
         /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
         /// <param name="partitionKey">Partition key of the resource.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
@@ -132,9 +132,9 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Query documents from the configured Cosmos container using pagination and a custom result.
+        /// Query documents from the configured Cosmos container using IQueryable and pagination.
         /// </summary>
-        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <typeparam name="TResult">The type of the query result.</typeparam>
         /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
         /// <param name="partitionKey">Partition key of the resource.</param>
         /// <param name="pageSize">The number of items to return per page.</param>
@@ -170,9 +170,9 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Query documents across partitions from the configured Cosmos container and returns a custom result.
+        /// Query documents across partitions from the configured Cosmos container using IQueryable.
         /// </summary>
-        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <typeparam name="TResult">The type of the query result.</typeparam>
         /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
         /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="TResult"/> resources.</returns>
@@ -210,9 +210,9 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Query documents across partitions from the configured Cosmos container using pagination and a custom result.
+        /// Query documents across partitions from the configured Cosmos container using IQueryable and pagination.
         /// </summary>
-        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <typeparam name="TResult">The type of the query result.</typeparam>
         /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
         /// <param name="pageSize">The number of items to return per page.</param>
         /// <param name="continuationToken">The continuationToken for getting the next page of a previous query.</param>
@@ -261,9 +261,9 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Query documents from the configured Cosmos container and returns a custom result.
+        /// Query documents from the configured Cosmos container using IQueryable and returns results in batches.
         /// </summary>
-        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <typeparam name="TResult">The type of the query result.</typeparam>
         /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
         /// <param name="partitionKey">Partition key of the resource.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
@@ -295,9 +295,9 @@ namespace Atc.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Query documents across partitions from the configured Cosmos container and returns a custom result.
+        /// Query documents across partitions from the configured Cosmos container using IQueryable and returns a results in batches.
         /// </summary>
-        /// <typeparam name="TResult">The type used for the custom query result.</typeparam>
+        /// <typeparam name="TResult">The type of the query result.</typeparam>
         /// <param name="queryBuilder">Query builder. Should return IQueryable corresponding to desired Cosmos query.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used.</param>
         /// <returns>An <see cref="IAsyncEnumerable&lt;T&gt;"/> over the requested <typeparamref name="TResult"/> resources.</returns>

--- a/src/Atc.Cosmos/Internal/CosmosReader.cs
+++ b/src/Atc.Cosmos/Internal/CosmosReader.cs
@@ -164,6 +164,19 @@ namespace Atc.Cosmos.Internal
             };
         }
 
+        public Task<PagedResult<TResult>> PagedQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            string partitionKey,
+            int? pageSize,
+            string? continuationToken = default,
+            CancellationToken cancellationToken = default)
+            => PagedQueryAsync<TResult>(
+                QueryBuilderToQueryDefinition(queryBuilder),
+                partitionKey,
+                pageSize,
+                continuationToken,
+                cancellationToken);
+
         public IAsyncEnumerable<T> CrossPartitionQueryAsync(
             QueryDefinition query,
             CancellationToken cancellationToken = default)
@@ -186,6 +199,11 @@ namespace Atc.Cosmos.Internal
                 }
             }
         }
+
+        public IAsyncEnumerable<TResult> CrossPartitionQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            CancellationToken cancellationToken = default)
+            => CrossPartitionQueryAsync<TResult>(QueryBuilderToQueryDefinition(queryBuilder), cancellationToken);
 
         public Task<PagedResult<T>> CrossPartitionPagedQueryAsync(
             QueryDefinition query,
@@ -224,6 +242,17 @@ namespace Atc.Cosmos.Internal
                 ContinuationToken = result.ContinuationToken,
             };
         }
+
+        public Task<PagedResult<TResult>> CrossPartitionPagedQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            int? pageSize,
+            string? continuationToken = default,
+            CancellationToken cancellationToken = default)
+            => CrossPartitionPagedQueryAsync<TResult>(
+                QueryBuilderToQueryDefinition(queryBuilder),
+                pageSize,
+                continuationToken,
+                cancellationToken);
 
         public async IAsyncEnumerable<IEnumerable<T>> BatchReadAllAsync(
             string partitionKey,
@@ -274,6 +303,12 @@ namespace Atc.Cosmos.Internal
             }
         }
 
+        public IAsyncEnumerable<IEnumerable<TResult>> BatchQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+            => BatchQueryAsync<TResult>(QueryBuilderToQueryDefinition(queryBuilder), partitionKey, cancellationToken);
+
         public IAsyncEnumerable<IEnumerable<T>> BatchCrossPartitionQueryAsync(
             QueryDefinition query,
             CancellationToken cancellationToken = default)
@@ -294,6 +329,11 @@ namespace Atc.Cosmos.Internal
                 yield return documents;
             }
         }
+
+        public IAsyncEnumerable<IEnumerable<TResult>> BatchCrossPartitionQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            CancellationToken cancellationToken = default)
+            => BatchCrossPartitionQueryAsync<TResult>(QueryBuilderToQueryDefinition(queryBuilder), cancellationToken);
 
         private QueryDefinition QueryBuilderToQueryDefinition<TResult>(
             Func<IQueryable<T>, IQueryable<TResult>> queryBuilder)

--- a/src/Atc.Cosmos/Internal/CosmosReader.cs
+++ b/src/Atc.Cosmos/Internal/CosmosReader.cs
@@ -92,7 +92,10 @@ namespace Atc.Cosmos.Internal
             Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
             string partitionKey,
             CancellationToken cancellationToken = default)
-            => QueryAsync<TResult>(QueryBuilderToQueryDefinition(queryBuilder), partitionKey, cancellationToken);
+            => QueryAsync<TResult>(
+                QueryBuilderToQueryDefinition(queryBuilder),
+                partitionKey,
+                cancellationToken);
 
         public async IAsyncEnumerable<TResult> QueryAsync<TResult>(
             QueryDefinition query,
@@ -203,7 +206,9 @@ namespace Atc.Cosmos.Internal
         public IAsyncEnumerable<TResult> CrossPartitionQueryAsync<TResult>(
             Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
             CancellationToken cancellationToken = default)
-            => CrossPartitionQueryAsync<TResult>(QueryBuilderToQueryDefinition(queryBuilder), cancellationToken);
+            => CrossPartitionQueryAsync<TResult>(
+                QueryBuilderToQueryDefinition(queryBuilder),
+                cancellationToken);
 
         public Task<PagedResult<T>> CrossPartitionPagedQueryAsync(
             QueryDefinition query,
@@ -307,7 +312,10 @@ namespace Atc.Cosmos.Internal
             Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
             string partitionKey,
             CancellationToken cancellationToken = default)
-            => BatchQueryAsync<TResult>(QueryBuilderToQueryDefinition(queryBuilder), partitionKey, cancellationToken);
+            => BatchQueryAsync<TResult>(
+                QueryBuilderToQueryDefinition(queryBuilder),
+                partitionKey,
+                cancellationToken);
 
         public IAsyncEnumerable<IEnumerable<T>> BatchCrossPartitionQueryAsync(
             QueryDefinition query,
@@ -333,7 +341,9 @@ namespace Atc.Cosmos.Internal
         public IAsyncEnumerable<IEnumerable<TResult>> BatchCrossPartitionQueryAsync<TResult>(
             Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
             CancellationToken cancellationToken = default)
-            => BatchCrossPartitionQueryAsync<TResult>(QueryBuilderToQueryDefinition(queryBuilder), cancellationToken);
+            => BatchCrossPartitionQueryAsync<TResult>(
+                QueryBuilderToQueryDefinition(queryBuilder),
+                cancellationToken);
 
         private QueryDefinition QueryBuilderToQueryDefinition<TResult>(
             Func<IQueryable<T>, IQueryable<TResult>> queryBuilder)

--- a/src/Atc.Cosmos/Internal/CosmosReader.cs
+++ b/src/Atc.Cosmos/Internal/CosmosReader.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Linq;
 using Microsoft.Extensions.Options;
 
 namespace Atc.Cosmos.Internal
@@ -85,6 +87,12 @@ namespace Atc.Cosmos.Internal
             string partitionKey,
             CancellationToken cancellationToken = default)
             => QueryAsync<T>(query, partitionKey, cancellationToken);
+
+        public IAsyncEnumerable<TResult> QueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+            => QueryAsync<TResult>(QueryBuilderToQueryDefinition(queryBuilder), partitionKey, cancellationToken);
 
         public async IAsyncEnumerable<TResult> QueryAsync<TResult>(
             QueryDefinition query,
@@ -286,5 +294,9 @@ namespace Atc.Cosmos.Internal
                 yield return documents;
             }
         }
+
+        private QueryDefinition QueryBuilderToQueryDefinition<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder)
+            => queryBuilder(container.GetItemLinqQueryable<T>()).ToQueryDefinition();
     }
 }

--- a/src/Atc.Cosmos/Testing/FakeCosmos.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmos.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -118,6 +119,16 @@ namespace Atc.Cosmos.Testing
             => ((ICosmosReader<T>)Reader)
                 .QueryAsync<TResult>(
                     query,
+                    partitionKey,
+                    cancellationToken);
+
+        public IAsyncEnumerable<TResult> QueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+            => ((ICosmosReader<T>)Reader)
+                .QueryAsync(
+                    queryBuilder,
                     partitionKey,
                     cancellationToken);
 

--- a/src/Atc.Cosmos/Testing/FakeCosmos.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmos.cs
@@ -10,17 +10,17 @@ using Microsoft.Azure.Cosmos;
 namespace Atc.Cosmos.Testing
 {
     [SuppressMessage(
-       "Design",
-       "MA0016:Prefer return collection abstraction instead of implementation",
-       Justification = "By design")]
+        "Design",
+        "MA0016:Prefer return collection abstraction instead of implementation",
+        Justification = "By design")]
     [SuppressMessage(
-       "Design",
-       "CA1002:Do not expose generic lists",
-       Justification = "By design")]
+        "Design",
+        "CA1002:Do not expose generic lists",
+        Justification = "By design")]
     [SuppressMessage(
-       "Usage",
-       "CA2227:Collection properties should be read only",
-       Justification = "By design")]
+        "Usage",
+        "CA2227:Collection properties should be read only",
+        Justification = "By design")]
     public sealed class FakeCosmos<T> :
         ICosmosReader<T>,
         ICosmosWriter<T>,
@@ -30,15 +30,15 @@ namespace Atc.Cosmos.Testing
     {
         public FakeCosmos()
             : this(
-                  new FakeCosmosReader<T>(),
-                  new FakeCosmosWriter<T>())
+                new FakeCosmosReader<T>(),
+                new FakeCosmosWriter<T>())
         {
         }
 
         public FakeCosmos(JsonSerializerOptions options)
             : this(
-                  new FakeCosmosReader<T>(options),
-                  new FakeCosmosWriter<T>(options))
+                new FakeCosmosReader<T>(options),
+                new FakeCosmosWriter<T>(options))
         {
         }
 
@@ -160,6 +160,20 @@ namespace Atc.Cosmos.Testing
                     continuationToken,
                     cancellationToken);
 
+        public Task<PagedResult<TResult>> PagedQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            string partitionKey,
+            int? pageSize,
+            string? continuationToken = default,
+            CancellationToken cancellationToken = default)
+            => ((ICosmosReader<T>)Reader)
+                .PagedQueryAsync(
+                    queryBuilder,
+                    partitionKey,
+                    pageSize,
+                    continuationToken,
+                    cancellationToken);
+
         IAsyncEnumerable<T> ICosmosReader<T>.CrossPartitionQueryAsync(
             QueryDefinition query,
             CancellationToken cancellationToken)
@@ -174,6 +188,14 @@ namespace Atc.Cosmos.Testing
             => ((ICosmosReader<T>)Reader)
                 .CrossPartitionQueryAsync<TResult>(
                     query,
+                    cancellationToken);
+
+        public IAsyncEnumerable<TResult> CrossPartitionQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            CancellationToken cancellationToken = default)
+            => ((ICosmosReader<T>)Reader)
+                .CrossPartitionQueryAsync(
+                    queryBuilder,
                     cancellationToken);
 
         Task<PagedResult<T>> ICosmosReader<T>.CrossPartitionPagedQueryAsync(
@@ -196,6 +218,18 @@ namespace Atc.Cosmos.Testing
             => ((ICosmosReader<T>)Reader)
                 .CrossPartitionPagedQueryAsync<TResult>(
                     query,
+                    pageSize,
+                    continuationToken,
+                    cancellationToken);
+
+        public Task<PagedResult<TResult>> CrossPartitionPagedQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            int? pageSize,
+            string? continuationToken = default,
+            CancellationToken cancellationToken = default)
+            => ((ICosmosReader<T>)Reader)
+                .CrossPartitionPagedQueryAsync(
+                    queryBuilder,
                     pageSize,
                     continuationToken,
                     cancellationToken);
@@ -228,6 +262,16 @@ namespace Atc.Cosmos.Testing
                     partitionKey,
                     cancellationToken);
 
+        public IAsyncEnumerable<IEnumerable<TResult>> BatchQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+            => ((ICosmosReader<T>)Reader)
+                .BatchQueryAsync(
+                    queryBuilder,
+                    partitionKey,
+                    cancellationToken);
+
         IAsyncEnumerable<IEnumerable<T>> ICosmosReader<T>.BatchCrossPartitionQueryAsync(
             QueryDefinition query,
             CancellationToken cancellationToken) => throw new NotImplementedException();
@@ -236,6 +280,14 @@ namespace Atc.Cosmos.Testing
             QueryDefinition query,
             CancellationToken cancellationToken) =>
             throw new NotImplementedException();
+
+        public IAsyncEnumerable<IEnumerable<TResult>> BatchCrossPartitionQueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            CancellationToken cancellationToken = default)
+            => ((ICosmosReader<T>)Reader)
+                .BatchCrossPartitionQueryAsync(
+                    queryBuilder,
+                    cancellationToken);
 
         Task<T?> ICosmosBulkReader<T>.FindAsync(
             string documentId,
@@ -489,12 +541,12 @@ namespace Atc.Cosmos.Testing
             string? filterPredicate,
             CancellationToken cancellationToken)
             => ((ICosmosWriter<T>)Writer)
-            .PatchAsync(
-                documentId,
-                partitionKey,
-                patchOperations,
-                filterPredicate,
-                cancellationToken);
+                .PatchAsync(
+                    documentId,
+                    partitionKey,
+                    patchOperations,
+                    filterPredicate,
+                    cancellationToken);
 
         Task ICosmosWriter<T>.PatchWithNoResponseAsync(
             string documentId,
@@ -511,12 +563,12 @@ namespace Atc.Cosmos.Testing
                     cancellationToken);
 
         Task ICosmosBulkWriter<T>.CreateAsync(
-             T document,
-             CancellationToken cancellationToken)
-             => ((ICosmosBulkWriter<T>)Writer)
-                 .CreateAsync(
-                     document,
-                     cancellationToken);
+            T document,
+            CancellationToken cancellationToken)
+            => ((ICosmosBulkWriter<T>)Writer)
+                .CreateAsync(
+                    document,
+                    cancellationToken);
 
         Task ICosmosBulkWriter<T>.WriteAsync(
             T document,

--- a/src/Atc.Cosmos/Testing/FakeCosmos.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmos.cs
@@ -10,17 +10,17 @@ using Microsoft.Azure.Cosmos;
 namespace Atc.Cosmos.Testing
 {
     [SuppressMessage(
-        "Design",
-        "MA0016:Prefer return collection abstraction instead of implementation",
-        Justification = "By design")]
+       "Design",
+       "MA0016:Prefer return collection abstraction instead of implementation",
+       Justification = "By design")]
     [SuppressMessage(
-        "Design",
-        "CA1002:Do not expose generic lists",
-        Justification = "By design")]
+       "Design",
+       "CA1002:Do not expose generic lists",
+       Justification = "By design")]
     [SuppressMessage(
-        "Usage",
-        "CA2227:Collection properties should be read only",
-        Justification = "By design")]
+       "Usage",
+       "CA2227:Collection properties should be read only",
+       Justification = "By design")]
     public sealed class FakeCosmos<T> :
         ICosmosReader<T>,
         ICosmosWriter<T>,
@@ -30,15 +30,15 @@ namespace Atc.Cosmos.Testing
     {
         public FakeCosmos()
             : this(
-                new FakeCosmosReader<T>(),
-                new FakeCosmosWriter<T>())
+                  new FakeCosmosReader<T>(),
+                  new FakeCosmosWriter<T>())
         {
         }
 
         public FakeCosmos(JsonSerializerOptions options)
             : this(
-                new FakeCosmosReader<T>(options),
-                new FakeCosmosWriter<T>(options))
+                  new FakeCosmosReader<T>(options),
+                  new FakeCosmosWriter<T>(options))
         {
         }
 
@@ -541,12 +541,12 @@ namespace Atc.Cosmos.Testing
             string? filterPredicate,
             CancellationToken cancellationToken)
             => ((ICosmosWriter<T>)Writer)
-                .PatchAsync(
-                    documentId,
-                    partitionKey,
-                    patchOperations,
-                    filterPredicate,
-                    cancellationToken);
+            .PatchAsync(
+                documentId,
+                partitionKey,
+                patchOperations,
+                filterPredicate,
+                cancellationToken);
 
         Task ICosmosWriter<T>.PatchWithNoResponseAsync(
             string documentId,
@@ -563,12 +563,12 @@ namespace Atc.Cosmos.Testing
                     cancellationToken);
 
         Task ICosmosBulkWriter<T>.CreateAsync(
-            T document,
-            CancellationToken cancellationToken)
-            => ((ICosmosBulkWriter<T>)Writer)
-                .CreateAsync(
-                    document,
-                    cancellationToken);
+             T document,
+             CancellationToken cancellationToken)
+             => ((ICosmosBulkWriter<T>)Writer)
+                 .CreateAsync(
+                     document,
+                     cancellationToken);
 
         Task ICosmosBulkWriter<T>.WriteAsync(
             T document,

--- a/src/Atc.Cosmos/Testing/FakeCosmosReader.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmosReader.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -120,6 +121,16 @@ namespace Atc.Cosmos.Testing
             => GetAsyncEnumerator(QueryResults
                 .OfType<TResult>()
                 .Clone(options));
+
+        public IAsyncEnumerable<TResult> QueryAsync<TResult>(
+            Func<IQueryable<T>, IQueryable<TResult>> queryBuilder,
+            string partitionKey,
+            CancellationToken cancellationToken = default)
+            => GetAsyncEnumerator(
+                queryBuilder(
+                    Documents
+                        .Where(d => d.PartitionKey == partitionKey)
+                        .AsQueryable()));
 
         public virtual Task<PagedResult<T>> PagedQueryAsync(
             QueryDefinition query,

--- a/test/Atc.Cosmos.Tests/Testing/FakeCosmosReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/Testing/FakeCosmosReaderTests.cs
@@ -332,7 +332,7 @@ namespace Atc.Cosmos.Tests.Testing
                 var result = await sut.CrossPartitionPagedQueryAsync(x => x.Where(_ => true), 1, continuationToken);
                 continuationToken = result.ContinuationToken;
                 requiredDocuments.Should().Contain(result.Items);
-                requiredDocuments.Remove(result.Items.First());
+                requiredDocuments.Remove(result.Items[0]);
             }
         }
 

--- a/test/Atc.Cosmos.Tests/Testing/FakeCosmosReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/Testing/FakeCosmosReaderTests.cs
@@ -124,6 +124,73 @@ namespace Atc.Cosmos.Tests.Testing
         }
 
         [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Should_Return_All_Documents_With_PartitionKey_When_Given_CatchAll_Query(
+            FakeCosmosReader<Record> sut,
+            Record[] queryResults,
+            string partitionKey)
+        {
+            foreach (var queryResult in queryResults)
+            {
+                queryResult.Pk = partitionKey;
+            }
+
+            sut.Documents.AddRange(queryResults);
+
+            var results = await sut
+                .QueryAsync(
+                    x => x.Where(_ => true),
+                    partitionKey)
+                .ToListAsync();
+
+            results
+                .Should()
+                .BeEquivalentTo(queryResults);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Should_Return_No_Documents_With_Unused_PartitionKey(
+            FakeCosmosReader<Record> sut,
+            Record[] queryResults,
+            string partitionKey)
+        {
+            sut.Documents.AddRange(queryResults);
+
+            var results = await sut
+                .QueryAsync(
+                    x => x.Where(_ => true),
+                    partitionKey)
+                .ToListAsync();
+
+            results
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Should_Return_No_Documents_With_PartitionKey_When_Given_CatchNone_Query(
+            FakeCosmosReader<Record> sut,
+            Record[] queryResults,
+            string partitionKey)
+        {
+            foreach (var queryResult in queryResults)
+            {
+                queryResult.Pk = partitionKey;
+            }
+
+            sut.Documents.AddRange(queryResults);
+
+            var results = await sut
+                .QueryAsync(
+                    x => x.Where(_ => false),
+                    partitionKey)
+                .ToListAsync();
+
+            results
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
         public async Task QueryAsync_Of_T_Should_Return_All_QueryResults_Of_Requested_Type(
             FakeCosmosReader<Record> sut,
             QueryDefinition query,

--- a/test/Atc.Cosmos.Tests/Testing/FakeCosmosReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/Testing/FakeCosmosReaderTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Atc.Cosmos.Testing;
 using Atc.Test;
+using AutoFixture;
 using AutoFixture.Xunit2;
 using Dasync.Collections;
 using FluentAssertions;
@@ -126,15 +127,11 @@ namespace Atc.Cosmos.Tests.Testing
         [Theory, AutoNSubstituteData]
         public async Task QueryAsync_Should_Return_All_Documents_With_PartitionKey_When_Given_CatchAll_Query(
             FakeCosmosReader<Record> sut,
-            Record[] queryResults,
+            Record[] recordsForQuery,
             string partitionKey)
         {
-            foreach (var queryResult in queryResults)
-            {
-                queryResult.Pk = partitionKey;
-            }
-
-            sut.Documents.AddRange(queryResults);
+            sut.Documents.AddRange(recordsForQuery);
+            sut.Documents.ForEach(d => d.Pk = partitionKey);
 
             var results = await sut
                 .QueryAsync(
@@ -144,16 +141,16 @@ namespace Atc.Cosmos.Tests.Testing
 
             results
                 .Should()
-                .BeEquivalentTo(queryResults);
+                .BeEquivalentTo(sut.Documents);
         }
 
         [Theory, AutoNSubstituteData]
         public async Task QueryAsync_Should_Return_No_Documents_With_Unused_PartitionKey(
             FakeCosmosReader<Record> sut,
-            Record[] queryResults,
+            Record[] recordsForQuery,
             string partitionKey)
         {
-            sut.Documents.AddRange(queryResults);
+            sut.Documents.AddRange(recordsForQuery);
 
             var results = await sut
                 .QueryAsync(
@@ -167,17 +164,13 @@ namespace Atc.Cosmos.Tests.Testing
         }
 
         [Theory, AutoNSubstituteData]
-        public async Task QueryAsync_Should_Return_No_Documents_With_PartitionKey_When_Given_CatchNone_Query(
+        public async Task QueryAsync_Should_Return_No_Documents_When_Given_CatchNone_Query(
             FakeCosmosReader<Record> sut,
-            Record[] queryResults,
+            Record[] recordsForQuery,
             string partitionKey)
         {
-            foreach (var queryResult in queryResults)
-            {
-                queryResult.Pk = partitionKey;
-            }
-
-            sut.Documents.AddRange(queryResults);
+            sut.Documents.AddRange(recordsForQuery);
+            sut.Documents.ForEach(d => d.Pk = partitionKey);
 
             var results = await sut
                 .QueryAsync(
@@ -261,6 +254,37 @@ namespace Atc.Cosmos.Tests.Testing
         }
 
         [Theory, AutoNSubstituteData]
+        public async Task PagedQueryAsync_With_LINQ_Should_Return_Result_In_Pages(
+            FakeCosmosReader<Record> sut,
+            Record[] recordsForQuery,
+            string partitionKey)
+        {
+            sut.Documents.Clear();
+            sut.Documents.AddRange(recordsForQuery);
+            sut.Documents.ForEach(x => x.Pk = partitionKey);
+
+            var page1 = await sut
+                .PagedQueryAsync(
+                    x => x.Where(_ => true),
+                    partitionKey,
+                    1,
+                    null);
+            var page2 = await sut
+                .PagedQueryAsync(
+                    x => x.Where(_ => true),
+                    partitionKey,
+                    1,
+                    page1.ContinuationToken);
+
+            page1.Items
+                .Should()
+                .BeEquivalentTo(new[] { recordsForQuery[0] });
+            page2.Items
+                .Should()
+                .BeEquivalentTo(new[] { recordsForQuery[1] });
+        }
+
+        [Theory, AutoNSubstituteData]
         public async Task PagedQueryAsync_Of_T_Should_Return_Result_In_Pages(
             FakeCosmosReader<Record> sut,
             QueryDefinition query,
@@ -288,6 +312,60 @@ namespace Atc.Cosmos.Tests.Testing
             page2.Items
                 .Should()
                 .BeEquivalentTo(new[] { queryResults[1] });
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionQuery_Should_Return_All_Documents_When_Given_CatchAll_Query(FakeCosmosReader<Record> sut)
+        {
+            var result = await sut.CrossPartitionQueryAsync(x => x.Where(_ => true)).ToListAsync();
+            result.Should().BeEquivalentTo(sut.Documents);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task PagedCrossPartitionQuery_Should_Return_All_Documents_When_Given_CatchAll_Query(FakeCosmosReader<Record> sut)
+        {
+            var requiredDocuments = new HashSet<Record>(sut.Documents);
+            string? continuationToken = null;
+
+            while (requiredDocuments.Any())
+            {
+                var result = await sut.CrossPartitionPagedQueryAsync(x => x.Where(_ => true), 1, continuationToken);
+                continuationToken = result.ContinuationToken;
+                requiredDocuments.Should().Contain(result.Items);
+                requiredDocuments.Remove(result.Items.First());
+            }
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task BatchQuery_Should_Return_All_Documents_When_Given_CatchAll_Query(
+            FakeCosmosReader<Record> sut,
+            Record[] recordsForQuery,
+            string partitionKey)
+        {
+            sut.Documents.AddRange(recordsForQuery);
+            sut.Documents.ForEach(x => x.Pk = partitionKey);
+
+            var result = await sut.BatchQueryAsync(x => x.Where(_ => true), partitionKey).ToListAsync();
+
+            result[0].Should().HaveCount(3); // Fake implementation of BatchQueryAsync will return batches of size 3
+            result[0].Should().NotBeEquivalentTo(recordsForQuery); // First 3 will be those already in sut.Documents before we inserted our own
+            result[1].Should().HaveCount(3);
+            result[1].Should().BeEquivalentTo(recordsForQuery); // The next 3 should be those query results that we inserted
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task BatchCrossPartitionQuery_Should_Return_All_Documents_When_Given_CatchAll_Query(
+            FakeCosmosReader<Record> sut,
+            Record[] recordsForQuery)
+        {
+            sut.Documents.AddRange(recordsForQuery);
+
+            var result = await sut.BatchCrossPartitionQueryAsync(x => x.Where(_ => true)).ToListAsync();
+
+            result[0].Should().HaveCount(3); // Fake implementation of BatchCrossPartitionQueryAsync will return batches of size 3
+            result[0].Should().NotBeEquivalentTo(recordsForQuery); // First 3 will be those already in sut.Documents before we inserted our own
+            result[1].Should().HaveCount(3);
+            result[1].Should().BeEquivalentTo(recordsForQuery); // The next 3 should be those query results that we inserted
         }
 
         [Theory, AutoNSubstituteData]


### PR DESCRIPTION
This adds LINQ-based query overloads for:

- QueryAsync
- PagedQueryAsync
- CrossPartitionQueryAsync
- CrossPartitionPagedQueryAsync
- BatchQueryAsync
- BatchCrossPartitionQueryAsync

Usage:
```csharp
reader.CrossPartitionQueryAsync(queryable => 
    queryable
        .Where(x => x.Foo == "something")
        .Select(x => x.Bar));
```

Also added fake implementations in FakeCosmosReader, which will apply the queryable on the internal documents collection. This means queries should function as expected in tests as well.