### PR TITLE
Removed allocation of cosmos client for every call to Get[Bulk]Client

### DIFF
--- a/src/Atc.Cosmos/Internal/CosmosClientProvider.cs
+++ b/src/Atc.Cosmos/Internal/CosmosClientProvider.cs
@@ -27,10 +27,10 @@ namespace Atc.Cosmos.Internal
         }
 
         public CosmosClient GetClient(CosmosOptions options)
-            => cosmosClientCache.AddOrUpdate(options, CreateClient(options, allowBulk: false), (o, c) => c);
+            => cosmosClientCache.AddOrUpdate(options, _ => CreateClient(options, allowBulk: false), (o, c) => c);
 
         public CosmosClient GetBulkClient(CosmosOptions options)
-            => cosmosBulkClientCache.AddOrUpdate(options, CreateClient(options, allowBulk: true), (o, c) => c);
+            => cosmosBulkClientCache.AddOrUpdate(options, _ => CreateClient(options, allowBulk: true), (o, c) => c);
 
         public void Dispose()
         {


### PR DESCRIPTION
This PR removed the unnecessary allocation of cosmos client when ever the `GetClient` or `GetBulkClient` client is called internally.