### PR TITLE
Extending Change Feed Processor with option to configure 

### DIFF
--- a/src/Atc.Cosmos/ChangeFeedProcessorOptions.cs
+++ b/src/Atc.Cosmos/ChangeFeedProcessorOptions.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Atc.Cosmos
+{
+    /// <summary>
+    /// Options for configuring Cosmos change feed processor.
+    /// </summary>
+    public class ChangeFeedProcessorOptions
+    {
+        /// <summary>
+        /// Gets or sets the delay in between polling the change feed for new changes, after all current changes are drained.
+        /// Default value is 1000ms.
+        /// <remarks>
+        /// Applies only after a read on the change feed yielded no results.
+        /// </remarks>
+        /// </summary>
+        public TimeSpan FeedPollDelay { get; set; } = TimeSpan.FromMilliseconds(1000);
+
+        /// <summary>
+        /// Gets or sets the maximum number of items to be returned in the enumeration operation in the Azure Cosmos DB service.
+        /// Default value is 100.
+        /// </summary>
+        public int MaxItemCount { get; set; } = 100;
+
+        /// The maximum parallel calls to the <see cref="IChangeFeedProcessor{T}"/>.
+        /// Default value is 1.
+        public int MaxDegreeOfParallelism { get; set; } = 1;
+
+        public static ChangeFeedProcessorOptions Default()
+        {
+            return new ChangeFeedProcessorOptions();
+        }
+    }
+}

--- a/src/Atc.Cosmos/DependencyInjection/CosmosBuilder{T}.cs
+++ b/src/Atc.Cosmos/DependencyInjection/CosmosBuilder{T}.cs
@@ -20,6 +20,17 @@ namespace Atc.Cosmos.DependencyInjection
             int maxDegreeOfParallelism = 1)
             where TProcessor : class, IChangeFeedProcessor<T>
         {
+            var changeFeedProcessorOptions = new ChangeFeedProcessorOptions()
+            {
+                MaxDegreeOfParallelism = maxDegreeOfParallelism,
+            };
+            return WithChangeFeedProcessor<TProcessor>(changeFeedProcessorOptions);
+        }
+
+        public ICosmosBuilder<T> WithChangeFeedProcessor<TProcessor>(
+            ChangeFeedProcessorOptions changeFeedProcessorOptions)
+            where TProcessor : class, IChangeFeedProcessor<T>
+        {
             Services.AddSingleton<LeasesContainerInitializer>();
             Services.AddSingleton<IScopedCosmosContainerInitializer>(
                 s => new ScopedCosmosContainerInitializer(
@@ -32,7 +43,7 @@ namespace Atc.Cosmos.DependencyInjection
             Services.AddSingleton(s => new ChangeFeedListener<T, TProcessor>(
                 s.GetRequiredService<IChangeFeedFactory>(),
                 s.GetRequiredService<TProcessor>(),
-                maxDegreeOfParallelism));
+                changeFeedProcessorOptions.MaxDegreeOfParallelism));
 
             Services.AddSingleton<IChangeFeedListener, ChangeFeedListener<T, TProcessor>>(
                 s => s.GetRequiredService<ChangeFeedListener<T, TProcessor>>());

--- a/src/Atc.Cosmos/DependencyInjection/CosmosContainerBuilder{T}.cs
+++ b/src/Atc.Cosmos/DependencyInjection/CosmosContainerBuilder{T}.cs
@@ -36,5 +36,26 @@ namespace Atc.Cosmos.DependencyInjection
 
             return this;
         }
+
+        public ICosmosContainerBuilder<T> WithChangeFeedProcessor<TProcessor>(
+            ChangeFeedProcessorOptions changeFeedProcessorOptions)
+            where TProcessor : class, IChangeFeedProcessor<T>
+        {
+            Services.AddSingleton<ICosmosContainerInitializer, LeasesContainerInitializer>();
+            Services.TryAddSingleton<IChangeFeedFactory, ChangeFeedFactory>();
+            Services.AddSingleton<TProcessor>();
+
+            Services.AddSingleton(s => new ChangeFeedListener<T, TProcessor>(
+                s.GetRequiredService<IChangeFeedFactory>(),
+                s.GetRequiredService<TProcessor>(),
+                changeFeedProcessorOptions));
+
+            Services.AddSingleton<IChangeFeedListener, ChangeFeedListener<T, TProcessor>>(
+                s => s.GetRequiredService<ChangeFeedListener<T, TProcessor>>());
+            Services.AddSingleton<IChangeFeedListener<T>, ChangeFeedListener<T, TProcessor>>(
+                s => s.GetRequiredService<ChangeFeedListener<T, TProcessor>>());
+
+            return this;
+        }
     }
 }

--- a/src/Atc.Cosmos/DependencyInjection/ICosmosBuilder{T}.cs
+++ b/src/Atc.Cosmos/DependencyInjection/ICosmosBuilder{T}.cs
@@ -19,5 +19,15 @@ namespace Atc.Cosmos.DependencyInjection
         ICosmosBuilder<T> WithChangeFeedProcessor<TProcessor>(
             int maxDegreeOfParallelism = 1)
             where TProcessor : class, IChangeFeedProcessor<T>;
+
+        /// <summary>
+        /// Adds a <see cref="IChangeFeedProcessor{T}"/> to the container.
+        /// </summary>
+        /// <typeparam name="TProcessor">The <see cref="IChangeFeedProcessor{T}"/> type.</typeparam>
+        /// <param name="changeFeedProcessorOptions">Configuration options for change feed processor <see cref="IChangeFeedProcessor{T}"/>.</param>
+        /// <returns>The <see cref="ICosmosBuilder{T}"/> instance.</returns>
+        ICosmosBuilder<T> WithChangeFeedProcessor<TProcessor>(
+            ChangeFeedProcessorOptions changeFeedProcessorOptions)
+            where TProcessor : class, IChangeFeedProcessor<T>;
     }
 }

--- a/src/Atc.Cosmos/DependencyInjection/ICosmosContainerBuilder{T}.cs
+++ b/src/Atc.Cosmos/DependencyInjection/ICosmosContainerBuilder{T}.cs
@@ -21,5 +21,15 @@ namespace Atc.Cosmos.DependencyInjection
         ICosmosContainerBuilder<T> WithChangeFeedProcessor<TProcessor>(
             int maxDegreeOfParallelism = 1)
             where TProcessor : class, IChangeFeedProcessor<T>;
+
+        /// <summary>
+        /// Adds a <see cref="IChangeFeedProcessor{T}"/> to the container.
+        /// </summary>
+        /// <typeparam name="TProcessor">The <see cref="IChangeFeedProcessor{T}"/> type.</typeparam>
+        /// <param name="changeFeedProcessorOptions">Configuration options for change feed processor.</param>
+        /// <returns>The <see cref="ICosmosContainerBuilder{T}"/> instance.</returns>
+        ICosmosContainerBuilder<T> WithChangeFeedProcessor<TProcessor>(
+            ChangeFeedProcessorOptions changeFeedProcessorOptions)
+            where TProcessor : class, IChangeFeedProcessor<T>;
     }
 }

--- a/src/Atc.Cosmos/Internal/ChangeFeedFactory.cs
+++ b/src/Atc.Cosmos/Internal/ChangeFeedFactory.cs
@@ -18,6 +18,15 @@ namespace Atc.Cosmos.Internal
             Container.ChangeFeedMonitorErrorDelegate? onError = null,
             string? processorName = null)
         {
+            return Create<T>(ChangeFeedProcessorOptions.Default(), onChanges, onError, processorName);
+        }
+
+        public ChangeFeedProcessor Create<T>(
+            ChangeFeedProcessorOptions changeFeedProcessorOptions,
+            Container.ChangesHandler<T> onChanges,
+            Container.ChangeFeedMonitorErrorDelegate? onError = null,
+            string? processorName = null)
+        {
             var container = containerProvider.GetContainer<T>();
 
             var builder = container
@@ -27,8 +36,8 @@ namespace Atc.Cosmos.Internal
                 .WithInstanceName(Guid.NewGuid().ToString())
                 .WithLeaseContainer(
                     containerProvider.GetContainerWithName<T>(LeasesContainerInitializer.ContainerId))
-                .WithMaxItems(100)
-                .WithPollInterval(TimeSpan.FromMilliseconds(1000))
+                .WithMaxItems(changeFeedProcessorOptions.MaxItemCount)
+                .WithPollInterval(changeFeedProcessorOptions.FeedPollDelay)
                 .WithStartTime(DateTime.MinValue.ToUniversalTime()); // Will start from the beginning of feed when no lease is found.
 
             if (onError != null)

--- a/src/Atc.Cosmos/Internal/IChangeFeedFactory.cs
+++ b/src/Atc.Cosmos/Internal/IChangeFeedFactory.cs
@@ -20,5 +20,20 @@ namespace Atc.Cosmos.Internal
             Container.ChangesHandler<T> onChanges,
             Container.ChangeFeedMonitorErrorDelegate? onError = null,
             string? processorName = null);
+
+        /// <summary>
+        /// Create a <see cref="ChangeFeedProcessor"/>.
+        /// </summary>
+        /// <typeparam name="T">The <see cref="ICosmosResource"/>.</typeparam>
+        /// <param name="changeFeedProcessorOptions">Configuration options for change feed processor.</param>
+        /// <param name="onChanges">Delegate to receive changes.</param>
+        /// <param name="onError">A delegate to receive notifications for change feed processor related errors.</param>
+        /// <param name="processorName">A name that identifies the Processor and the particular work it will do.</param>
+        /// <returns>A <see cref="ChangeFeedProcessor"/>.</returns>
+        ChangeFeedProcessor Create<T>(
+            ChangeFeedProcessorOptions changeFeedProcessorOptions,
+            Container.ChangesHandler<T> onChanges,
+            Container.ChangeFeedMonitorErrorDelegate? onError = null,
+            string? processorName = null);
     }
 }

--- a/test/Atc.Cosmos.Tests/Internal/ChangeFeedListenerTests.cs
+++ b/test/Atc.Cosmos.Tests/Internal/ChangeFeedListenerTests.cs
@@ -39,7 +39,7 @@ namespace Atc.Cosmos.Tests.Internal
             changeFeed = Substitute.For<ChangeFeedProcessor>();
             factory = Substitute.For<IChangeFeedFactory>();
             factory
-                .Create<Record>(default)
+                .Create<Record>(default, (Container.ChangesHandler<Record>)default)
                 .ReturnsForAnyArgs(changeFeed);
 
             sut = new ChangeFeedListener<Record, RecordProcessor>(
@@ -54,8 +54,10 @@ namespace Atc.Cosmos.Tests.Internal
             factory
                 .Received(1)
                 .Create<Record>(
+                    Arg.Any<ChangeFeedProcessorOptions>(),
                     Arg.Any<Container.ChangesHandler<Record>>(),
-                    Arg.Any<Container.ChangeFeedMonitorErrorDelegate>());
+                    Arg.Any<Container.ChangeFeedMonitorErrorDelegate>(),
+                    Arg.Any<string>());
         }
 
         [Theory, AutoNSubstituteData]


### PR DESCRIPTION
We need to give possibility to configure FeedPollInterval.

* Default (cosmos sdk) value should be 5000ms , but Atc-cosmos FeedPollInterval is hardcoded to 1000ms.
* on lower environments (like i.e DEV) we would like to limit that value so that not to pay much for querying 'Lease' container.