### PR TITLE
Change feed processor options - Added option to configure StartTime

### DIFF
--- a/src/Atc.Cosmos/ChangeFeedProcessorOptions.cs
+++ b/src/Atc.Cosmos/ChangeFeedProcessorOptions.cs
@@ -29,9 +29,9 @@ namespace Atc.Cosmos
         /// This is only used when:
         /// (1) Lease store is not initialized and is ignored if a lease exists and has continuation token.
         /// (2) StartContinuation is not specified.
-        /// If not specified, then default value will be taken DateTime.Min.
+        /// Default value is DateTime.Min.
         /// </remarks>
-        public DateTime? StartTime { get; set; }
+        public DateTime StartTime { get; set; } = DateTime.MinValue.ToUniversalTime();
 
         /// The maximum parallel calls to the <see cref="IChangeFeedProcessor{T}"/>.
         /// Default value is 1.

--- a/src/Atc.Cosmos/ChangeFeedProcessorOptions.cs
+++ b/src/Atc.Cosmos/ChangeFeedProcessorOptions.cs
@@ -22,6 +22,17 @@ namespace Atc.Cosmos
         /// </summary>
         public int MaxItemCount { get; set; } = 100;
 
+        /// <summary>
+        /// Gets or sets the time (exclusive) to start looking for changes after.
+        /// </summary>
+        /// <remarks>
+        /// This is only used when:
+        /// (1) Lease store is not initialized and is ignored if a lease exists and has continuation token.
+        /// (2) StartContinuation is not specified.
+        /// If not specified, then default value will be taken DateTime.Min.
+        /// </remarks>
+        public DateTime? StartTime { get; set; }
+
         /// The maximum parallel calls to the <see cref="IChangeFeedProcessor{T}"/>.
         /// Default value is 1.
         public int MaxDegreeOfParallelism { get; set; } = 1;

--- a/src/Atc.Cosmos/Internal/ChangeFeedFactory.cs
+++ b/src/Atc.Cosmos/Internal/ChangeFeedFactory.cs
@@ -38,7 +38,7 @@ namespace Atc.Cosmos.Internal
                     containerProvider.GetContainerWithName<T>(LeasesContainerInitializer.ContainerId))
                 .WithMaxItems(changeFeedProcessorOptions.MaxItemCount)
                 .WithPollInterval(changeFeedProcessorOptions.FeedPollDelay)
-                .WithStartTime(changeFeedProcessorOptions.StartTime ?? DateTime.MinValue.ToUniversalTime()/* Will start from the beginning of feed when no lease is found. */);
+                .WithStartTime(changeFeedProcessorOptions.StartTime);
 
             if (onError != null)
             {

--- a/src/Atc.Cosmos/Internal/ChangeFeedFactory.cs
+++ b/src/Atc.Cosmos/Internal/ChangeFeedFactory.cs
@@ -18,7 +18,7 @@ namespace Atc.Cosmos.Internal
             Container.ChangeFeedMonitorErrorDelegate? onError = null,
             string? processorName = null)
         {
-            return Create<T>(ChangeFeedProcessorOptions.Default(), onChanges, onError, processorName);
+            return Create(ChangeFeedProcessorOptions.Default(), onChanges, onError, processorName);
         }
 
         public ChangeFeedProcessor Create<T>(
@@ -38,7 +38,7 @@ namespace Atc.Cosmos.Internal
                     containerProvider.GetContainerWithName<T>(LeasesContainerInitializer.ContainerId))
                 .WithMaxItems(changeFeedProcessorOptions.MaxItemCount)
                 .WithPollInterval(changeFeedProcessorOptions.FeedPollDelay)
-                .WithStartTime(DateTime.MinValue.ToUniversalTime()); // Will start from the beginning of feed when no lease is found.
+                .WithStartTime(changeFeedProcessorOptions.StartTime ?? DateTime.MinValue.ToUniversalTime()/* Will start from the beginning of feed when no lease is found. */);
 
             if (onError != null)
             {


### PR DESCRIPTION
We need to give option to configure StartDateTime.

* to keep backward compatibilitiy, when StartDateTime isn't be defined, then DateTime.Min will be set
* there are some databases where data are not good quality (i.e junk data on DEV), and if we start processing then exceptions are thrown