### PR TITLE
Fix - changeFeedProcessor options not applied

### DIFF
--- a/src/Atc.Cosmos/DependencyInjection/CosmosBuilder{T}.cs
+++ b/src/Atc.Cosmos/DependencyInjection/CosmosBuilder{T}.cs
@@ -43,7 +43,7 @@ namespace Atc.Cosmos.DependencyInjection
             Services.AddSingleton(s => new ChangeFeedListener<T, TProcessor>(
                 s.GetRequiredService<IChangeFeedFactory>(),
                 s.GetRequiredService<TProcessor>(),
-                changeFeedProcessorOptions.MaxDegreeOfParallelism));
+                changeFeedProcessorOptions));
 
             Services.AddSingleton<IChangeFeedListener, ChangeFeedListener<T, TProcessor>>(
                 s => s.GetRequiredService<ChangeFeedListener<T, TProcessor>>());


### PR DESCRIPTION
This is follow-up of https://github.com/atc-net/atc-cosmos/pull/48 (Change feed processor options - Added option to configure StartTime)

We need this fix as otherwise old version (left for backward compatibility) gets applied, despite someone configures FeedPollInterval or StartTime