### PR TITLE
Feature/fixed application name validation exception

### DIFF
--- a/src/Atc.Cosmos/Atc.Cosmos.csproj
+++ b/src/Atc.Cosmos/Atc.Cosmos.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.29.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.34.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />

--- a/src/Atc.Cosmos/Internal/CosmosClientProvider.cs
+++ b/src/Atc.Cosmos/Internal/CosmosClientProvider.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using Atc.Cosmos.Serialization;
 using Microsoft.Azure.Cosmos;
@@ -70,7 +68,11 @@ namespace Atc.Cosmos.Internal
 
             if (cosmosClientOptions is { Value: { } o })
             {
-                result.ApplicationName = o.ApplicationName;
+                if (!string.IsNullOrEmpty(o.ApplicationName))
+                {
+                    result.ApplicationName = o.ApplicationName;
+                }
+
                 result.ApplicationPreferredRegions = o.ApplicationPreferredRegions;
                 result.ApplicationRegion = o.ApplicationRegion;
                 result.ConnectionMode = o.ConnectionMode;

--- a/test/Atc.Cosmos.Tests/Internal/CosmosClientProviderTests.cs
+++ b/test/Atc.Cosmos.Tests/Internal/CosmosClientProviderTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Text;
 using Atc.Cosmos.Internal;
 using Atc.Cosmos.Serialization;
@@ -10,7 +9,6 @@ using AutoFixture.AutoNSubstitute;
 using FluentAssertions;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Options;
-using Microsoft.Win32;
 using NSubstitute;
 using Xunit;
 
@@ -34,11 +32,7 @@ namespace Atc.Cosmos.Tests.Internal
                 DatabaseThroughput = fixture.Create<int>(),
             };
 
-            cosmosClientOptions = new CosmosClientOptions
-            {
-                ApplicationName = fixture.Create<string>(),
-            };
-
+            cosmosClientOptions = new CosmosClientOptions();
             serializer = Substitute.For<IJsonCosmosSerializer>();
 
             sut = new CosmosClientProvider(
@@ -60,6 +54,18 @@ namespace Atc.Cosmos.Tests.Internal
 
         [Fact]
         public void Client_Should_Use_CosmosClientOptions()
+            => sut
+                .GetClient(cosmosOptions)
+                .ClientOptions
+                .Should()
+                .BeEquivalentTo(
+                    cosmosClientOptions,
+                    o => o
+                        .Excluding(o => o.AllowBulkExecution)
+                        .Excluding(o => o.Serializer));
+
+        [Fact]
+        public void Client_Should_NotSet_CosmosClientOptions_ApplicationName_When_NotSpecified()
             => sut
                 .GetClient(cosmosOptions)
                 .ClientOptions


### PR DESCRIPTION
From version 3.31.0 of `Microsoft.Azure.Cosmos' an exception will be thrown when setting an empty ApplicationName on CosmosClientOptions.