### PR TITLE
Introduce Low Priority Readers and Writers using the Preview version of the Cosmos SDK

### DIFF
--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -51,7 +51,7 @@ jobs:
         run: dotnet pack -c Release -o packages -p:UseSourceLink=true -p:Version=${{ env.VERSION }} -p:PackageVersion=${{ env.VERSION }}-preview -p:DefineConstants=PREVIEW
 
       - name: 🧪 Run unit tests
-        run: dotnet test -c Release --no-build
+        run: dotnet test -c Release
 
       - name: 🌩️ SonarCloud install scanner
         run: dotnet tool install --global dotnet-sonarscanner

--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -51,7 +51,7 @@ jobs:
         run: dotnet pack -c Release -o packages -p:UseSourceLink=true -p:Version=${{ env.VERSION }} -p:PackageVersion=${{ env.VERSION }}-preview -p:DefineConstants=PREVIEW
 
       - name: 🧪 Run unit tests
-        run: dotnet test -c Release
+        run: dotnet test -c Release -p:DefineConstants=PREVIEW
 
       - name: 🌩️ SonarCloud install scanner
         run: dotnet tool install --global dotnet-sonarscanner
@@ -61,6 +61,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: pwsh
+        continue-on-error: true
         run: |
           dotnet sonarscanner begin /k:"atc-cosmos" /o:"atc-net" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
           dotnet build -c Release /p:UseSourceLink=true --no-restore
@@ -74,8 +75,13 @@ jobs:
           git merge --ff-only main
           git push origin stable
 
-      - name: 🗳️ Creating library package for pre-release
-        run: dotnet pack -c Release --no-restore -o ${GITHUB_WORKSPACE}/packages -p:RepositoryBranch=$BRANCH_NAME
-
       - name: 📦 Push packages to GitHub Package Registry
-        run: dotnet nuget push ${GITHUB_WORKSPACE}/packages/'Atc.Cosmos.'${NBGV_NuGetPackageVersion}'.nupkg' -k ${{ secrets.GITHUB_TOKEN }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols
+        run: dotnet nuget push **/*.nupkg -k ${{ secrets.GITHUB_TOKEN }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols
+
+      - name: 🗳️ Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Packages
+          path: |
+            packages/*.nupkg
+            README.md

--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -11,7 +11,7 @@ env:
   ATC_EMAIL: 'atcnet.org@gmail.com'
   ATC_NAME: 'Atc-Net'
   NUGET_REPO_URL: 'https://nuget.pkg.github.com/atc-net/index.json'
-  VERSION: 1.1.${{ github.run_number }}
+  VERSION: 1.1.0.${{ github.run_number }}
 
 jobs:
   merge-to-stable:

--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -11,7 +11,7 @@ env:
   ATC_EMAIL: 'atcnet.org@gmail.com'
   ATC_NAME: 'Atc-Net'
   NUGET_REPO_URL: 'https://nuget.pkg.github.com/atc-net/index.json'
-  VERSION: 1.0.${{ github.run_number }}
+  VERSION: 1.1.${{ github.run_number }}
 
 jobs:
   merge-to-stable:

--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -11,6 +11,7 @@ env:
   ATC_EMAIL: 'atcnet.org@gmail.com'
   ATC_NAME: 'Atc-Net'
   NUGET_REPO_URL: 'https://nuget.pkg.github.com/atc-net/index.json'
+  VERSION: 1.0.${{ github.run_number }}
 
 jobs:
   merge-to-stable:
@@ -43,11 +44,11 @@ jobs:
       - name: 🧹 Clean
         run: dotnet clean -c Release && dotnet nuget locals all --clear
 
-      - name: 🔁 Restore packages
-        run: dotnet restore
+      - name: 🛠️ Building library in release mode
+        run: dotnet pack -c Release -o packages -p:UseSourceLink=true -p:Version=${{ env.VERSION }} -p:PackageVersion=${{ env.VERSION }}
 
-      - name: 🛠️ Build
-        run: dotnet build -c Release --no-restore /p:UseSourceLink=true
+      - name: 🛠️ Building preview library in release mode
+        run: dotnet pack -c Release -o packages -p:UseSourceLink=true -p:Version=${{ env.VERSION }} -p:PackageVersion=${{ env.VERSION }}-preview -p:DefineConstants=PREVIEW
 
       - name: 🧪 Run unit tests
         run: dotnet test -c Release --no-build

--- a/.github/workflows/post-integration.yml
+++ b/.github/workflows/post-integration.yml
@@ -76,6 +76,7 @@ jobs:
           git push origin stable
 
       - name: 📦 Push packages to GitHub Package Registry
+        continue-on-error: true
         run: dotnet nuget push **/*.nupkg -k ${{ secrets.GITHUB_TOKEN }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols
 
       - name: 🗳️ Upload build artifacts

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -2,6 +2,7 @@ name: "Pre-Integration"
 
 on:
   push:
+  workflow_dispatch:
 
 env:
   VERSION: 1.0.${{ github.run_number }}

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -1,18 +1,14 @@
 name: "Pre-Integration"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
+  push:
+
+env:
+  VERSION: 1.0.${{ github.run_number }}
 
 jobs:
-  dotnet5-build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+  build:
+    runs-on: ubuntu-latest
     steps:
       - name: 🛒 Checkout repository
         uses: actions/checkout@v2
@@ -27,16 +23,24 @@ jobs:
       - name: 🧹 Clean
         run: dotnet clean -c Release && dotnet nuget locals all --clear
 
-      - name: 🔁 Restore packages
-        run: dotnet restore
-
       - name: 🛠️ Building library in release mode
-        run: dotnet build -c Release --no-restore
+        run: dotnet pack -c Release -o packages -p:UseSourceLink=true -p:Version=${{ env.VERSION }} -p:PackageVersion=${{ env.VERSION }}
 
-  dotnet-test:
+      - name: 🛠️ Building preview library in release mode
+        run: dotnet pack -c Release -o packages -p:UseSourceLink=true -p:Version=${{ env.VERSION }} -p:PackageVersion=${{ env.VERSION }}-preview -p:DefineConstants=PREVIEW
+
+      - name: 🗳️ Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Packages
+          path: |
+            packages/*.nupkg
+            README.md
+
+  test:
     runs-on: ubuntu-latest
     needs:
-      - dotnet5-build
+      - build
     steps:
       - name: 🛒 Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -56,8 +56,5 @@ jobs:
       - name: 🔁 Restore packages
         run: dotnet restore
 
-      - name: 🛠️ Build
-        run: dotnet build -c Release --no-restore /p:UseSourceLink=true
-
       - name: 🧪 Run unit tests
-        run: dotnet test -c Release --no-build
+        run: dotnet test -c Release -p:DefineConstants=PREVIEW

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.0.${{ github.run_number }}
+  VERSION: 1.1.${{ github.run_number }}
 
 jobs:
   build:

--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION: 1.1.${{ github.run_number }}
+  VERSION: 1.1.0.${{ github.run_number }}
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,21 @@ jobs:
       - name: 🛠️ Building preview library in release mode
         run: dotnet pack -c Release -o packages -p:UseSourceLink=true -p:Version=${{ env.VERSION }} -p:PackageVersion=${{ env.VERSION }}-preview -p:DefineConstants=PREVIEW
 
-      - name: ⏩ Merge to release-branch
-        run: |
-          git config --local user.email ${{ env.ATC_EMAIL }}
-          git config --local user.name ${{ env.ATC_NAME }}
-          git checkout release
-          git merge --ff-only stable
-          git push origin release
+      - name: 🗳️ Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Packages
+          path: |
+            packages/*.nupkg
+            README.md
 
-      - name: 📦 Push packages to NuGet
-        run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols
+      # - name: ⏩ Merge to release-branch
+      #   run: |
+      #     git config --local user.email ${{ env.ATC_EMAIL }}
+      #     git config --local user.name ${{ env.ATC_NAME }}
+      #     git checkout release
+      #     git merge --ff-only stable
+      #     git push origin release
+
+      # - name: 📦 Push packages to NuGet
+      #   run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,13 @@ jobs:
             packages/*.nupkg
             README.md
 
-      # - name: ⏩ Merge to release-branch
-      #   run: |
-      #     git config --local user.email ${{ env.ATC_EMAIL }}
-      #     git config --local user.name ${{ env.ATC_NAME }}
-      #     git checkout release
-      #     git merge --ff-only stable
-      #     git push origin release
+      - name: ⏩ Merge to release-branch
+        run: |
+          git config --local user.email ${{ env.ATC_EMAIL }}
+          git config --local user.name ${{ env.ATC_NAME }}
+          git checkout release
+          git merge --ff-only stable
+          git push origin release
 
-      # - name: 📦 Push packages to NuGet
-      #   run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols
+      - name: 📦 Push packages to NuGet
+        run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ env:
   ATC_EMAIL: 'atcnet.org@gmail.com'
   ATC_NAME: 'Atc-Net'
   NUGET_REPO_URL: 'https://api.nuget.org/v3/index.json'
+  VERSION: 1.1.${{ github.run_number }}
 
 jobs:
   release:
@@ -19,14 +20,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.PAT_WORKFLOWS }}
 
-      - name: ⚛️ Sets environment variables - branch-name
-        uses: nelonoel/branch-name@v1.0.1
-
-      - name: ⚛️ Sets environment variables - Nerdbank.GitVersioning
-        uses: dotnet/nbgv@master
-        with:
-          setAllVars: true
-
       - name: ⚙️ Setup dotnet 6.0.x
         uses: actions/setup-dotnet@v1
         with:
@@ -35,11 +28,11 @@ jobs:
       - name: 🧹 Clean
         run: dotnet clean -c Release && dotnet nuget locals all --clear
 
-      - name: 🔁 Restore packages
-        run: dotnet restore
-
       - name: 🛠️ Building library in release mode
-        run: dotnet build -c Release --no-restore /p:UseSourceLink=true
+        run: dotnet pack -c Release -o packages -p:UseSourceLink=true -p:Version=${{ env.VERSION }} -p:PackageVersion=${{ env.VERSION }}
+
+      - name: 🛠️ Building preview library in release mode
+        run: dotnet pack -c Release -o packages -p:UseSourceLink=true -p:Version=${{ env.VERSION }} -p:PackageVersion=${{ env.VERSION }}-preview -p:DefineConstants=PREVIEW
 
       - name: ⏩ Merge to release-branch
         run: |
@@ -49,8 +42,5 @@ jobs:
           git merge --ff-only stable
           git push origin release
 
-      - name: 🗳️ Creating library package for release
-        run: dotnet pack -c Release --no-restore -o ${GITHUB_WORKSPACE}/packages -p:RepositoryBranch=$BRANCH_NAME /p:PublicRelease=true
-
       - name: 📦 Push packages to NuGet
-        run: dotnet nuget push ${GITHUB_WORKSPACE}/packages/'Atc.Cosmos.'${NBGV_NuGetPackageVersion}'.nupkg' -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols
+        run: dotnet nuget push **/*.nupkg -k ${{ secrets.NUGET_KEY }} -s ${{ env.NUGET_REPO_URL }} --skip-duplicate --no-symbols

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "Atc.Cosmos.sln"
+}

--- a/Atc.Cosmos.sln
+++ b/Atc.Cosmos.sln
@@ -11,16 +11,26 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
+		Debug Preview|Any CPU = Debug Preview|Any CPU
+		Release Preview|Any CPU = Release Preview|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{AD8BA566-1E47-4E9E-BEBA-985DCA7A0DB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AD8BA566-1E47-4E9E-BEBA-985DCA7A0DB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AD8BA566-1E47-4E9E-BEBA-985DCA7A0DB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AD8BA566-1E47-4E9E-BEBA-985DCA7A0DB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD8BA566-1E47-4E9E-BEBA-985DCA7A0DB5}.Debug Preview|Any CPU.ActiveCfg = Debug Preview|Any CPU
+		{AD8BA566-1E47-4E9E-BEBA-985DCA7A0DB5}.Debug Preview|Any CPU.Build.0 = Debug Preview|Any CPU
+		{AD8BA566-1E47-4E9E-BEBA-985DCA7A0DB5}.Release Preview|Any CPU.ActiveCfg = Release Preview|Any CPU
+		{AD8BA566-1E47-4E9E-BEBA-985DCA7A0DB5}.Release Preview|Any CPU.Build.0 = Release Preview|Any CPU
 		{16FE83BC-DF0D-493D-8EE0-A78006A07EFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{16FE83BC-DF0D-493D-8EE0-A78006A07EFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{16FE83BC-DF0D-493D-8EE0-A78006A07EFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{16FE83BC-DF0D-493D-8EE0-A78006A07EFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16FE83BC-DF0D-493D-8EE0-A78006A07EFF}.Debug Preview|Any CPU.ActiveCfg = Debug Preview|Any CPU
+		{16FE83BC-DF0D-493D-8EE0-A78006A07EFF}.Debug Preview|Any CPU.Build.0 = Debug Preview|Any CPU
+		{16FE83BC-DF0D-493D-8EE0-A78006A07EFF}.Release Preview|Any CPU.ActiveCfg = Release Preview|Any CPU
+		{16FE83BC-DF0D-493D-8EE0-A78006A07EFF}.Release Preview|Any CPU.Build.0 = Release Preview|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
+
+  <PropertyGroup Label="configurations">
+    <Configurations>Debug;Release;Debug Preview;Release Preview</Configurations>
+    <Platforms>AnyCPU</Platforms>    
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug Preview' ">
+    <DefineConstants>TRACE;PREVIEW;</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release Preview' ">
+    <DefineConstants>TRACE;PREVIEW;</DefineConstants>
+    <Optimize>true</Optimize>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
 
   <PropertyGroup Label="Metadata configuration">
     <OrganizationName>atc-net</OrganizationName>
     <RepositoryName>atc-cosmos</RepositoryName>
+    <IsPreview>$(DefineConstants.Contains('PREVIEW'))</IsPreview>
   </PropertyGroup>
 
   <!-- Solution wide properties -->

--- a/src/Atc.Cosmos/Atc.Cosmos.csproj
+++ b/src/Atc.Cosmos/Atc.Cosmos.csproj
@@ -24,8 +24,4 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.5.109" />
-  </ItemGroup>
-
 </Project>

--- a/src/Atc.Cosmos/Atc.Cosmos.csproj
+++ b/src/Atc.Cosmos/Atc.Cosmos.csproj
@@ -4,15 +4,17 @@
     <PackageId>Atc.Cosmos</PackageId>
     <PackageTags>cosmos;cosmos-sql;netcore;repository</PackageTags>
     <Description>Library for configuring containers in Cosmos and providing an easy way to read and write document resources.</Description>
+    <VersionSuffix Condition="$(IsPreview)">preview</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.34.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.5" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.35.1-preview" Condition="$(IsPreview)" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.35.1" Condition="!$(IsPreview)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">

--- a/src/Atc.Cosmos/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Atc.Cosmos/DependencyInjection/ServiceCollectionExtensions.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ICosmosContainerProvider, CosmosContainerProvider>();
             services.AddSingleton(typeof(ICosmosReader<>), typeof(CosmosReader<>));
             services.AddSingleton(typeof(ICosmosWriter<>), typeof(CosmosWriter<>));
+            services.AddSingleton(typeof(ICosmosBulkReader<>), typeof(CosmosBulkReader<>));
             services.AddSingleton(typeof(ICosmosBulkWriter<>), typeof(CosmosBulkWriter<>));
             services.AddSingleton<ICosmosInitializer, CosmosInitializer>();
             services.AddSingleton<IJsonCosmosSerializer, JsonCosmosSerializer>();

--- a/src/Atc.Cosmos/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Atc.Cosmos/DependencyInjection/ServiceCollectionExtensions.cs
@@ -67,6 +67,14 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<ICosmosClientProvider, CosmosClientProvider>();
             services.AddSingleton<ICosmosReaderFactory, CosmosReaderFactory>();
             services.AddSingleton<ICosmosWriterFactory, CosmosWriterFactory>();
+#if PREVIEW
+            services.AddSingleton(typeof(ILowPriorityCosmosReader<>), typeof(LowPriorityCosmosReader<>));
+            services.AddSingleton(typeof(ILowPriorityCosmosWriter<>), typeof(LowPriorityCosmosWriter<>));
+            services.AddSingleton(typeof(ILowPriorityCosmosBulkReader<>), typeof(LowPriorityCosmosBulkReader<>));
+            services.AddSingleton(typeof(ILowPriorityCosmosBulkWriter<>), typeof(LowPriorityCosmosBulkWriter<>));
+            services.AddSingleton<ILowPriorityCosmosReaderFactory, LowPriorityCosmosReaderFactory>();
+            services.AddSingleton<ILowPriorityCosmosWriterFactory, LowPriorityCosmosWriterFactory>();
+#endif
 
             builder(new CosmosBuilder(services, registry, null));
             return services;

--- a/src/Atc.Cosmos/ILowPriorityCosmosBulkReader.cs
+++ b/src/Atc.Cosmos/ILowPriorityCosmosBulkReader.cs
@@ -1,0 +1,17 @@
+#if PREVIEW
+namespace Atc.Cosmos
+{
+    /// <summary>
+    /// Represents a reader that can perform bulk reads on Cosmos resources using the PriorityLevel Low.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of <see cref="ICosmosResource"/>
+    /// to be read by this reader.
+    /// </typeparam>
+    public interface ILowPriorityCosmosBulkReader<T>
+        : ICosmosBulkReader<T>
+        where T : class, ICosmosResource
+    {
+    }
+}
+#endif

--- a/src/Atc.Cosmos/ILowPriorityCosmosBulkWriter.cs
+++ b/src/Atc.Cosmos/ILowPriorityCosmosBulkWriter.cs
@@ -1,0 +1,17 @@
+#if PREVIEW
+namespace Atc.Cosmos
+{
+    /// <summary>
+    /// Represents a reader that can perform bulk reads on Cosmos resources using the PriorityLevel Low.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of <see cref="ICosmosResource"/>
+    /// to be read by this reader.
+    /// </typeparam>
+    public interface ILowPriorityCosmosBulkWriter<in T>
+        : ICosmosBulkWriter<T>
+        where T : class, ICosmosResource
+    {
+    }
+}
+#endif

--- a/src/Atc.Cosmos/ILowPriorityCosmosReader.cs
+++ b/src/Atc.Cosmos/ILowPriorityCosmosReader.cs
@@ -1,0 +1,17 @@
+#if PREVIEW
+namespace Atc.Cosmos
+{
+    /// <summary>
+    /// Represents a reader that can read Cosmos resources using the PriorityLevel Low.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of <see cref="ICosmosResource"/>
+    /// to be read by this reader.
+    /// </typeparam>
+    public interface ILowPriorityCosmosReader<T>
+        : ICosmosReader<T>
+        where T : class, ICosmosResource
+    {
+    }
+}
+#endif

--- a/src/Atc.Cosmos/ILowPriorityCosmosReaderFactory.cs
+++ b/src/Atc.Cosmos/ILowPriorityCosmosReaderFactory.cs
@@ -1,0 +1,26 @@
+#if PREVIEW
+namespace Atc.Cosmos
+{
+    /// <summary>
+    /// Represents a factory for creating <see cref="ICosmosReader{T}"/> instances.
+    /// </summary>
+    public interface ILowPriorityCosmosReaderFactory
+    {
+        /// <summary>
+        /// Create a <see cref="ICosmosReader{T}"/>.
+        /// </summary>
+        /// <typeparam name="TResource">The <see cref="ICosmosResource"/> for the <see cref="ICosmosReader{T}"/>.</typeparam>
+        /// <returns>A <see cref="ICosmosReader{T}"/>.</returns>
+        ILowPriorityCosmosReader<TResource> CreateReader<TResource>()
+            where TResource : class, ICosmosResource;
+
+        /// <summary>
+        /// Create a <see cref="ICosmosBulkReader{T}"/>.
+        /// </summary>
+        /// <typeparam name="TResource">The <see cref="ICosmosResource"/> for the <see cref="ICosmosBulkReader{T}"/>.</typeparam>
+        /// <returns>A <see cref="ICosmosBulkReader{T}"/>.</returns>
+        ILowPriorityCosmosBulkReader<TResource> CreateBulkReader<TResource>()
+            where TResource : class, ICosmosResource;
+    }
+}
+#endif

--- a/src/Atc.Cosmos/ILowPriorityCosmosWriter.cs
+++ b/src/Atc.Cosmos/ILowPriorityCosmosWriter.cs
@@ -1,0 +1,17 @@
+#if PREVIEW
+namespace Atc.Cosmos
+{
+    /// <summary>
+    /// Represents a writer that can write Cosmos resources using the PriorityLevel Low.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of <see cref="ICosmosResource"/>
+    /// to be read by this reader.
+    /// </typeparam>
+    public interface ILowPriorityCosmosWriter<T>
+        : ICosmosWriter<T>
+        where T : class, ICosmosResource
+    {
+    }
+}
+#endif

--- a/src/Atc.Cosmos/ILowPriorityCosmosWriterFactory.cs
+++ b/src/Atc.Cosmos/ILowPriorityCosmosWriterFactory.cs
@@ -1,0 +1,26 @@
+#if PREVIEW
+namespace Atc.Cosmos
+{
+    /// <summary>
+    /// Represents a factory for creating <see cref="ICosmosWriter{T}"/> instances.
+    /// </summary>
+    public interface ILowPriorityCosmosWriterFactory
+    {
+        /// <summary>
+        /// Create a <see cref="ICosmosWriter{T}"/>.
+        /// </summary>
+        /// <typeparam name="TResource">The <see cref="ICosmosResource"/> for the <see cref="ICosmosWriter{T}"/>.</typeparam>
+        /// <returns>A <see cref="ICosmosWriter{T}"/>.</returns>
+        ILowPriorityCosmosWriter<TResource> CreateWriter<TResource>()
+            where TResource : class, ICosmosResource;
+
+        /// <summary>
+        /// Create a <see cref="ICosmosBulkWriter{T}"/>.
+        /// </summary>
+        /// <typeparam name="TResource">The <see cref="ICosmosResource"/> for the <see cref="ICosmosBulkWriter{T}"/>.</typeparam>
+        /// <returns>A <see cref="ICosmosBulkWriter{T}"/>.</returns>
+        ILowPriorityCosmosBulkWriter<TResource> CreateBulkWriter<TResource>()
+            where TResource : class, ICosmosResource;
+    }
+}
+#endif

--- a/src/Atc.Cosmos/Internal/CosmosBulkReader.cs
+++ b/src/Atc.Cosmos/Internal/CosmosBulkReader.cs
@@ -18,6 +18,10 @@ namespace Atc.Cosmos.Internal
             this.container = containerProvider.GetContainer<T>(allowBulk: true);
         }
 
+#if PREVIEW
+        protected virtual PriorityLevel PriorityLevel => PriorityLevel.High;
+#endif
+
         public async Task<T> ReadAsync(
             string documentId,
             string partitionKey,
@@ -27,6 +31,12 @@ namespace Atc.Cosmos.Internal
                 .ReadItemAsync<T>(
                     documentId,
                     new PartitionKey(partitionKey),
+                    new ItemRequestOptions
+                    {
+#if PREVIEW
+                        PriorityLevel = PriorityLevel,
+#endif
+                    },
                     cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
@@ -62,6 +72,9 @@ namespace Atc.Cosmos.Internal
                 requestOptions: new QueryRequestOptions
                 {
                     PartitionKey = new PartitionKey(partitionKey),
+#if PREVIEW
+                    PriorityLevel = PriorityLevel,
+#endif
                 });
 
             while (reader.HasMoreResults && !cancellationToken.IsCancellationRequested)
@@ -92,6 +105,9 @@ namespace Atc.Cosmos.Internal
                 requestOptions: new QueryRequestOptions
                 {
                     PartitionKey = new PartitionKey(partitionKey),
+#if PREVIEW
+                    PriorityLevel = PriorityLevel,
+#endif
                 });
 
             while (reader.HasMoreResults && !cancellationToken.IsCancellationRequested)
@@ -133,6 +149,9 @@ namespace Atc.Cosmos.Internal
                 {
                     PartitionKey = new PartitionKey(partitionKey),
                     MaxItemCount = pageSize,
+#if PREVIEW
+                    PriorityLevel = PriorityLevel,
+#endif
                 });
 
             if (!reader.HasMoreResults)
@@ -193,6 +212,9 @@ namespace Atc.Cosmos.Internal
                 requestOptions: new QueryRequestOptions
                 {
                     MaxItemCount = pageSize,
+#if PREVIEW
+                    PriorityLevel = PriorityLevel,
+#endif
                 });
 
             if (!reader.HasMoreResults)
@@ -220,6 +242,9 @@ namespace Atc.Cosmos.Internal
                 requestOptions: new QueryRequestOptions
                 {
                     PartitionKey = new PartitionKey(partitionKey),
+#if PREVIEW
+                    PriorityLevel = PriorityLevel,
+#endif
                 });
 
             while (reader.HasMoreResults && !cancellationToken.IsCancellationRequested)
@@ -248,6 +273,9 @@ namespace Atc.Cosmos.Internal
                 requestOptions: new QueryRequestOptions
                 {
                     PartitionKey = new PartitionKey(partitionKey),
+#if PREVIEW
+                    PriorityLevel = PriorityLevel,
+#endif
                 });
 
             while (reader.HasMoreResults && !cancellationToken.IsCancellationRequested)

--- a/src/Atc.Cosmos/Internal/CosmosWriter.cs
+++ b/src/Atc.Cosmos/Internal/CosmosWriter.cs
@@ -27,6 +27,10 @@ namespace Atc.Cosmos.Internal
             this.serializer = serializer;
         }
 
+#if PREVIEW
+        protected virtual PriorityLevel PriorityLevel => PriorityLevel.High;
+#endif
+
         public Task<T> CreateAsync(
             T document,
             CancellationToken cancellationToken = default)
@@ -34,7 +38,12 @@ namespace Atc.Cosmos.Internal
                 .CreateItemAsync<object>(
                     document,
                     new PartitionKey(document.PartitionKey),
-                    new ItemRequestOptions { },
+                    new ItemRequestOptions
+                    {
+#if PREVIEW
+                        PriorityLevel = PriorityLevel,
+#endif
+                    },
                     cancellationToken)
                 .GetResourceWithEtag<T>(serializer);
 
@@ -45,7 +54,13 @@ namespace Atc.Cosmos.Internal
                 .CreateItemAsync<object>(
                     document,
                     new PartitionKey(document.PartitionKey),
-                    new ItemRequestOptions { EnableContentResponseOnWrite = false },
+                    new ItemRequestOptions
+                    {
+                        EnableContentResponseOnWrite = false,
+#if PREVIEW
+                        PriorityLevel = PriorityLevel,
+#endif
+                    },
                     cancellationToken);
 
         public Task<T> WriteAsync(
@@ -55,7 +70,12 @@ namespace Atc.Cosmos.Internal
                 .UpsertItemAsync<object>(
                     document,
                     new PartitionKey(document.PartitionKey),
-                    new ItemRequestOptions { },
+                    new ItemRequestOptions
+                    {
+#if PREVIEW
+                        PriorityLevel = PriorityLevel,
+#endif
+                    },
                     cancellationToken)
                 .GetResourceWithEtag<T>(serializer);
 
@@ -66,7 +86,13 @@ namespace Atc.Cosmos.Internal
                 .UpsertItemAsync<object>(
                     document,
                     new PartitionKey(document.PartitionKey),
-                    new ItemRequestOptions { EnableContentResponseOnWrite = false },
+                    new ItemRequestOptions
+                    {
+                        EnableContentResponseOnWrite = false,
+#if PREVIEW
+                        PriorityLevel = PriorityLevel,
+#endif
+                    },
                     cancellationToken);
 
         public Task<T> ReplaceAsync(
@@ -80,6 +106,9 @@ namespace Atc.Cosmos.Internal
                     new ItemRequestOptions
                     {
                         IfMatchEtag = document.ETag,
+#if PREVIEW
+                        PriorityLevel = PriorityLevel,
+#endif
                     },
                     cancellationToken)
                 .GetResourceWithEtag<T>(serializer);
@@ -96,6 +125,9 @@ namespace Atc.Cosmos.Internal
                     {
                         IfMatchEtag = document.ETag,
                         EnableContentResponseOnWrite = false,
+#if PREVIEW
+                        PriorityLevel = PriorityLevel,
+#endif
                     },
                     cancellationToken);
 
@@ -107,6 +139,12 @@ namespace Atc.Cosmos.Internal
                 .DeleteItemAsync<object>(
                     documentId,
                     new PartitionKey(partitionKey),
+                    new ItemRequestOptions
+                    {
+#if PREVIEW
+                        PriorityLevel = PriorityLevel,
+#endif
+                    },
                     cancellationToken: cancellationToken);
 
         public async Task<bool> TryDeleteAsync(
@@ -120,6 +158,12 @@ namespace Atc.Cosmos.Internal
                     .DeleteItemAsync<object>(
                         documentId,
                         new PartitionKey(partitionKey),
+                        new ItemRequestOptions
+                        {
+#if PREVIEW
+                            PriorityLevel = PriorityLevel,
+#endif
+                        },
                         cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
@@ -270,6 +314,9 @@ namespace Atc.Cosmos.Internal
                     new PatchItemRequestOptions
                     {
                         FilterPredicate = filterPredicate,
+#if PREVIEW
+                        PriorityLevel = PriorityLevel,
+#endif
                     },
                     cancellationToken)
                 .GetResourceWithEtag<T>(serializer);
@@ -289,6 +336,9 @@ namespace Atc.Cosmos.Internal
                     {
                         FilterPredicate = filterPredicate,
                         EnableContentResponseOnWrite = false,
+#if PREVIEW
+                        PriorityLevel = PriorityLevel,
+#endif
                     },
                     cancellationToken);
 

--- a/src/Atc.Cosmos/Internal/CosmosWriterFactory.cs
+++ b/src/Atc.Cosmos/Internal/CosmosWriterFactory.cs
@@ -28,7 +28,6 @@ namespace Atc.Cosmos.Internal
         public ICosmosBulkWriter<TResource> CreateBulkWriter<TResource>()
             where TResource : class, ICosmosResource
             => new CosmosBulkWriter<TResource>(
-                provider,
-                serializer);
+                provider);
     }
 }

--- a/src/Atc.Cosmos/Internal/LowPriorityCosmosBulkReader.cs
+++ b/src/Atc.Cosmos/Internal/LowPriorityCosmosBulkReader.cs
@@ -1,0 +1,19 @@
+#if PREVIEW
+using Atc.Cosmos.Internal;
+using Microsoft.Azure.Cosmos;
+
+namespace Atc.Cosmos
+{
+    public class LowPriorityCosmosBulkReader<T>
+        : CosmosBulkReader<T>, ILowPriorityCosmosBulkReader<T>
+        where T : class, ICosmosResource
+    {
+        public LowPriorityCosmosBulkReader(ICosmosContainerProvider containerProvider)
+            : base(containerProvider)
+        {
+        }
+
+        protected override PriorityLevel PriorityLevel => PriorityLevel.Low;
+    }
+}
+#endif

--- a/src/Atc.Cosmos/Internal/LowPriorityCosmosBulkWriter.cs
+++ b/src/Atc.Cosmos/Internal/LowPriorityCosmosBulkWriter.cs
@@ -1,0 +1,22 @@
+#if PREVIEW
+using Atc.Cosmos.Internal;
+using Atc.Cosmos.Serialization;
+using Microsoft.Azure.Cosmos;
+
+namespace Atc.Cosmos
+{
+    public class LowPriorityCosmosBulkWriter<T>
+        : CosmosBulkWriter<T>, ILowPriorityCosmosBulkWriter<T>
+        where T : class, ICosmosResource
+    {
+        public LowPriorityCosmosBulkWriter(
+            ICosmosContainerProvider containerProvider,
+            IJsonCosmosSerializer serializer)
+            : base(containerProvider)
+        {
+        }
+
+        protected override PriorityLevel PriorityLevel => PriorityLevel.Low;
+    }
+}
+#endif

--- a/src/Atc.Cosmos/Internal/LowPriorityCosmosReader.cs
+++ b/src/Atc.Cosmos/Internal/LowPriorityCosmosReader.cs
@@ -1,0 +1,19 @@
+#if PREVIEW
+using Atc.Cosmos.Internal;
+using Microsoft.Azure.Cosmos;
+
+namespace Atc.Cosmos
+{
+    public class LowPriorityCosmosReader<T>
+        : CosmosReader<T>, ILowPriorityCosmosReader<T>
+        where T : class, ICosmosResource
+    {
+        public LowPriorityCosmosReader(ICosmosContainerProvider containerProvider)
+            : base(containerProvider)
+        {
+        }
+
+        protected override PriorityLevel PriorityLevel => PriorityLevel.Low;
+    }
+}
+#endif

--- a/src/Atc.Cosmos/Internal/LowPriorityCosmosReaderFactory.cs
+++ b/src/Atc.Cosmos/Internal/LowPriorityCosmosReaderFactory.cs
@@ -1,0 +1,25 @@
+#if PREVIEW
+using Atc.Cosmos.Internal;
+
+namespace Atc.Cosmos
+{
+    public class LowPriorityCosmosReaderFactory : ILowPriorityCosmosReaderFactory
+    {
+        private readonly ICosmosContainerProvider provider;
+
+        public LowPriorityCosmosReaderFactory(
+            ICosmosContainerProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        public ILowPriorityCosmosReader<TResource> CreateReader<TResource>()
+            where TResource : class, ICosmosResource
+            => new LowPriorityCosmosReader<TResource>(provider);
+
+        public ILowPriorityCosmosBulkReader<TResource> CreateBulkReader<TResource>()
+            where TResource : class, ICosmosResource
+            => new LowPriorityCosmosBulkReader<TResource>(provider);
+    }
+}
+#endif

--- a/src/Atc.Cosmos/Internal/LowPriorityCosmosWriter.cs
+++ b/src/Atc.Cosmos/Internal/LowPriorityCosmosWriter.cs
@@ -1,0 +1,23 @@
+#if PREVIEW
+using Atc.Cosmos.Internal;
+using Atc.Cosmos.Serialization;
+using Microsoft.Azure.Cosmos;
+
+namespace Atc.Cosmos
+{
+    public class LowPriorityCosmosWriter<T>
+        : CosmosWriter<T>, ILowPriorityCosmosWriter<T>
+        where T : class, ICosmosResource
+    {
+        public LowPriorityCosmosWriter(
+            ICosmosContainerProvider containerProvider,
+            ILowPriorityCosmosReader<T> reader,
+            IJsonCosmosSerializer serializer)
+            : base(containerProvider, reader, serializer)
+        {
+        }
+
+        protected override PriorityLevel PriorityLevel => PriorityLevel.Low;
+    }
+}
+#endif

--- a/src/Atc.Cosmos/Internal/LowPriorityCosmosWriterFactory.cs
+++ b/src/Atc.Cosmos/Internal/LowPriorityCosmosWriterFactory.cs
@@ -1,0 +1,35 @@
+#if PREVIEW
+using Atc.Cosmos.Internal;
+using Atc.Cosmos.Serialization;
+
+namespace Atc.Cosmos
+{
+    public class LowPriorityCosmosWriterFactory : ILowPriorityCosmosWriterFactory
+    {
+        private readonly ICosmosContainerProvider provider;
+        private readonly ILowPriorityCosmosReaderFactory factory;
+        private readonly IJsonCosmosSerializer serializer;
+
+        public LowPriorityCosmosWriterFactory(
+            ICosmosContainerProvider provider,
+            ILowPriorityCosmosReaderFactory factory,
+            IJsonCosmosSerializer serializer)
+        {
+            this.provider = provider;
+            this.factory = factory;
+            this.serializer = serializer;
+        }
+
+        public ILowPriorityCosmosWriter<TResource> CreateWriter<TResource>()
+            where TResource : class, ICosmosResource
+            => new LowPriorityCosmosWriter<TResource>(
+                provider,
+                factory.CreateReader<TResource>(),
+                serializer);
+
+        public ILowPriorityCosmosBulkWriter<TResource> CreateBulkWriter<TResource>()
+            where TResource : class, ICosmosResource
+            => new LowPriorityCosmosBulkWriter<TResource>(provider, serializer);
+    }
+}
+#endif

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -55,7 +55,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/test/Atc.Cosmos.Tests/CosmosBulkReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosBulkReaderTests.cs
@@ -87,7 +87,11 @@ namespace Atc.Cosmos.Tests
                 .ReadItemAsync<Record>(
                     documentId,
                     new PartitionKey(partitionKey),
+#if PREVIEW
+                    Arg.Is<ItemRequestOptions>(c => c.PriorityLevel == PriorityLevel.High),
+#else
                     Arg.Any<ItemRequestOptions>(),
+#endif
                     cancellationToken);
         }
 

--- a/test/Atc.Cosmos.Tests/CosmosBulkWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosBulkWriterTests.cs
@@ -47,7 +47,7 @@ namespace Atc.Cosmos.Tests
                 .FromString<Record>(default)
                 .ReturnsForAnyArgs(new Fixture().Create<Record>());
 
-            sut = new CosmosBulkWriter<Record>(containerProvider, serializer);
+            sut = new CosmosBulkWriter<Record>(containerProvider);
         }
 
         [Fact]

--- a/test/Atc.Cosmos.Tests/CosmosReaderBatchTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosReaderBatchTests.cs
@@ -184,7 +184,8 @@ namespace Atc.Cosmos.Tests
         {
             feedIterator.HasMoreResults.Returns(false);
 
-            var response = await sut.BatchQueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+            var response = await sut.BatchQueryAsync(query, partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
 
             _ = feedIterator
                 .Received(1)
@@ -207,7 +208,8 @@ namespace Atc.Cosmos.Tests
         {
             feedIterator.HasMoreResults.Returns(true, false);
 
-            var response = await sut.BatchQueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+            var response = await sut.BatchQueryAsync(query, partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
 
             _ = feedIterator
                 .Received(2)
@@ -237,7 +239,8 @@ namespace Atc.Cosmos.Tests
                 .GetEnumerator()
                 .Returns(new List<Record> { record }.GetEnumerator());
 
-            var response = await sut.BatchQueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+            var response = await sut.BatchQueryAsync(query, partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
 
             _ = feedIterator
                 .Received(2)
@@ -294,7 +297,8 @@ namespace Atc.Cosmos.Tests
         {
             feedIterator.HasMoreResults.Returns(false);
 
-            var response = await sut.BatchQueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+            var response = await sut.BatchQueryAsync<Record>(query, partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
 
             _ = feedIterator
                 .Received(1)
@@ -317,7 +321,8 @@ namespace Atc.Cosmos.Tests
         {
             feedIterator.HasMoreResults.Returns(true, false);
 
-            var response = await sut.BatchQueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+            var response = await sut.BatchQueryAsync<Record>(query, partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
 
             _ = feedIterator
                 .Received(2)
@@ -347,7 +352,8 @@ namespace Atc.Cosmos.Tests
                 .GetEnumerator()
                 .Returns(new List<Record> { record }.GetEnumerator());
 
-            var response = await sut.BatchQueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+            var response = await sut.BatchQueryAsync<Record>(query, partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
 
             _ = feedIterator
                 .Received(2)
@@ -380,7 +386,7 @@ namespace Atc.Cosmos.Tests
         }
 
         [Theory, AutoNSubstituteData]
-        public void CrossPartitionQueryAsync_Does_Not_Specify_QueryRequestOptions(
+        public void CrossPartitionQueryAsync_Uses_QueryRequestOptions_With_PriorityLevel_High(
             QueryDefinition query,
             CancellationToken cancellationToken)
         {
@@ -388,7 +394,13 @@ namespace Atc.Cosmos.Tests
 
             container
                 .Received(1)
-                .GetItemQueryIterator<Record>(query, requestOptions: null);
+                .GetItemQueryIterator<Record>(
+                    query,
+#if PREVIEW
+                    requestOptions: Arg.Is<QueryRequestOptions>(c => c.PriorityLevel == PriorityLevel.High));
+#else
+                    requestOptions: Arg.Any<QueryRequestOptions>());
+#endif
         }
 
         [Theory, AutoNSubstituteData]
@@ -398,7 +410,8 @@ namespace Atc.Cosmos.Tests
         {
             feedIterator.HasMoreResults.Returns(false);
 
-            var response = await sut.BatchCrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+            var response = await sut.BatchCrossPartitionQueryAsync(query, cancellationToken)
+                .ToListAsync(cancellationToken);
 
             _ = feedIterator
                 .Received(1)
@@ -420,7 +433,8 @@ namespace Atc.Cosmos.Tests
         {
             feedIterator.HasMoreResults.Returns(true, false);
 
-            var response = await sut.BatchCrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+            var response = await sut.BatchCrossPartitionQueryAsync(query, cancellationToken)
+                .ToListAsync(cancellationToken);
 
             _ = feedIterator
                 .Received(2)
@@ -449,7 +463,8 @@ namespace Atc.Cosmos.Tests
                 .GetEnumerator()
                 .Returns(new List<Record> { record }.GetEnumerator());
 
-            var response = await sut.BatchCrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+            var response = await sut.BatchCrossPartitionQueryAsync(query, cancellationToken)
+                .ToListAsync(cancellationToken);
 
             _ = feedIterator
                 .Received(2)

--- a/test/Atc.Cosmos.Tests/CosmosWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosWriterTests.cs
@@ -92,7 +92,11 @@ namespace Atc.Cosmos.Tests
                 .UpsertItemAsync<object>(
                     record,
                     new PartitionKey(record.Pk),
+#if PREVIEW
+                    Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.High),
+#else
                     Arg.Any<ItemRequestOptions>(),
+#endif
                     cancellationToken);
         }
 
@@ -110,13 +114,17 @@ namespace Atc.Cosmos.Tests
                 .UpsertItemAsync<object>(
                     record,
                     new PartitionKey(record.Pk),
+#if PREVIEW
+                    Arg.Is<ItemRequestOptions>(p => p.EnableContentResponseOnWrite == false && p.PriorityLevel == PriorityLevel.High),
+#else
                     Arg.Is<ItemRequestOptions>(p => p.EnableContentResponseOnWrite == false),
+#endif
                     cancellationToken);
         }
 
         [Theory, AutoNSubstituteData]
         public async Task CreateAsync_Calls_CreateItem_On_Container(
-           CancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await sut.CreateAsync(record, cancellationToken);
             _ = container
@@ -124,13 +132,17 @@ namespace Atc.Cosmos.Tests
                 .CreateItemAsync<object>(
                     record,
                     new PartitionKey(record.Pk),
+#if PREVIEW
+                    Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.High),
+#else
                     Arg.Any<ItemRequestOptions>(),
+#endif
                     cancellationToken);
         }
 
         [Theory, AutoNSubstituteData]
         public async Task CreateWithNoResponseAsync_Calls_CreateItem_On_Container(
-           CancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await sut.CreateWithNoResponseAsync(record, cancellationToken);
             _ = container
@@ -138,13 +150,17 @@ namespace Atc.Cosmos.Tests
                 .CreateItemAsync<object>(
                     record,
                     new PartitionKey(record.Pk),
+#if PREVIEW
+                    Arg.Is<ItemRequestOptions>(p => p.EnableContentResponseOnWrite == false && p.PriorityLevel == PriorityLevel.High),
+#else
                     Arg.Is<ItemRequestOptions>(p => p.EnableContentResponseOnWrite == false),
+#endif
                     cancellationToken);
         }
 
         [Theory, AutoNSubstituteData]
         public async Task ReplaceAsync_Calls_ReplaceItemAsync_On_Container(
-           CancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await sut.ReplaceAsync(record, cancellationToken);
             _ = container
@@ -153,13 +169,17 @@ namespace Atc.Cosmos.Tests
                     record,
                     record.Id,
                     new PartitionKey(record.Pk),
-                    Arg.Is<ItemRequestOptions>(o => o.IfMatchEtag == ((ICosmosResource)record).ETag),
+#if PREVIEW
+                    Arg.Is<ItemRequestOptions>(o => o.IfMatchEtag == record.ETag && o.PriorityLevel == PriorityLevel.High),
+#else
+                    Arg.Is<ItemRequestOptions>(o => o.IfMatchEtag == record.ETag),
+#endif
                     cancellationToken);
         }
 
         [Theory, AutoNSubstituteData]
         public async Task ReplaceWithNoResponseAsync_Calls_ReplaceItemAsync_On_Container(
-           CancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await sut.ReplaceWithNoResponseAsync(record, cancellationToken);
             _ = container
@@ -168,8 +188,12 @@ namespace Atc.Cosmos.Tests
                     record,
                     record.Id,
                     new PartitionKey(record.Pk),
-                    Arg.Is<ItemRequestOptions>(o => o.IfMatchEtag == ((ICosmosResource)record).ETag
-                                                 && o.EnableContentResponseOnWrite == false),
+                    Arg.Is<ItemRequestOptions>(
+                        o => o.IfMatchEtag == record.ETag
+#if PREVIEW
+                             && o.PriorityLevel == PriorityLevel.High
+#endif
+                             && o.EnableContentResponseOnWrite == false),
                     cancellationToken);
         }
 
@@ -192,7 +216,7 @@ namespace Atc.Cosmos.Tests
 
         [Theory, AutoNSubstituteData]
         public async Task DeleteAsync_Calls_DeleteItemAsync_On_Container(
-           CancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await sut.DeleteAsync(record.Id, record.Pk, cancellationToken);
             _ = container
@@ -200,13 +224,17 @@ namespace Atc.Cosmos.Tests
                 .DeleteItemAsync<object>(
                     record.Id,
                     new PartitionKey(record.Pk),
+#if PREVIEW
+                    Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.High),
+#else
                     Arg.Any<ItemRequestOptions>(),
+#endif
                     cancellationToken: cancellationToken);
         }
 
         [Theory, AutoNSubstituteData]
         public async Task Should_Return_True_When_Trying_To_Delete_Existing_Resource(
-           CancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             var deleted = await sut.TryDeleteAsync(
                 record.Id,
@@ -222,13 +250,17 @@ namespace Atc.Cosmos.Tests
                 .DeleteItemAsync<object>(
                     record.Id,
                     new PartitionKey(record.Pk),
+#if PREVIEW
+                    Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.High),
+#else
                     Arg.Any<ItemRequestOptions>(),
+#endif
                     cancellationToken: cancellationToken);
         }
 
         [Theory, AutoNSubstituteData]
         public async Task Should_Return_False_When_Trying_To_Delete_NonExisting_Resource(
-           CancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             container
                 .DeleteItemAsync<object>(default, default, default, default)
@@ -249,7 +281,11 @@ namespace Atc.Cosmos.Tests
                 .DeleteItemAsync<object>(
                     record.Id,
                     new PartitionKey(record.Pk),
+#if PREVIEW
+                    Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.High),
+#else
                     Arg.Any<ItemRequestOptions>(),
+#endif
                     cancellationToken: cancellationToken);
         }
 
@@ -317,16 +353,21 @@ namespace Atc.Cosmos.Tests
                     record,
                     record.Id,
                     new PartitionKey(record.Pk),
-                    Arg.Is<ItemRequestOptions>(o => o.IfMatchEtag == ((ICosmosResource)record).ETag),
+#if PREVIEW
+                    Arg.Is<ItemRequestOptions>(
+                        o => o.IfMatchEtag == record.ETag && o.PriorityLevel == PriorityLevel.High),
+#else
+                    Arg.Is<ItemRequestOptions>(o => o.IfMatchEtag == record.ETag),
+#endif
                     cancellationToken);
         }
 
         [Theory, AutoNSubstituteData]
         public async Task UpdateOrCreateAsync_Finds_The_Resource(
-           Action<Record> updateDocument,
-           int retries,
-           Record defaultDocument,
-           CancellationToken cancellationToken)
+            Action<Record> updateDocument,
+            int retries,
+            Record defaultDocument,
+            CancellationToken cancellationToken)
         {
             await sut.UpdateOrCreateAsync(
                 () => defaultDocument,
@@ -432,7 +473,11 @@ namespace Atc.Cosmos.Tests
                 .CreateItemAsync<object>(
                     defaultDocument,
                     new PartitionKey(defaultDocument.Pk),
+#if PREVIEW
+                    Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.High),
+#else
                     Arg.Any<ItemRequestOptions>(),
+#endif
                     cancellationToken);
         }
 
@@ -455,7 +500,11 @@ namespace Atc.Cosmos.Tests
                     record.Id,
                     new PartitionKey(record.Pk),
                     patchOperations,
+#if PREVIEW
+                    Arg.Is<PatchItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.High),
+#else
                     Arg.Any<PatchItemRequestOptions>(),
+#endif
                     cancellationToken);
         }
 
@@ -478,7 +527,11 @@ namespace Atc.Cosmos.Tests
                     record.Id,
                     new PartitionKey(record.Pk),
                     patchOperations,
+#if PREVIEW
+                    Arg.Is<PatchItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.High),
+#else
                     Arg.Any<PatchItemRequestOptions>(),
+#endif
                     cancellationToken);
         }
     }

--- a/test/Atc.Cosmos.Tests/LowPriorityCosmosBulkReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/LowPriorityCosmosBulkReaderTests.cs
@@ -1,0 +1,805 @@
+#if PREVIEW
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Atc.Cosmos.Internal;
+using Atc.Test;
+using AutoFixture;
+using Dasync.Collections;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Atc.Cosmos.Tests
+{
+    public class LowPriorityCosmosBulkReaderTests
+    {
+        private readonly ItemResponse<Record> itemResponse;
+        private readonly FeedIterator<Record> feedIterator;
+        private readonly FeedResponse<Record> feedResponse;
+        private readonly Record record;
+        private readonly Container container;
+        private readonly ICosmosContainerProvider containerProvider;
+        private readonly LowPriorityCosmosBulkReader<Record> sut;
+
+        public LowPriorityCosmosBulkReaderTests()
+        {
+            record = new Fixture().Create<Record>();
+            itemResponse = Substitute.For<ItemResponse<Record>>();
+            itemResponse
+                .Resource
+                .Returns(record);
+
+            feedResponse = Substitute.For<FeedResponse<Record>>();
+            feedIterator = Substitute.For<FeedIterator<Record>>();
+            feedIterator
+                .ReadNextAsync(default)
+                .ReturnsForAnyArgs(feedResponse);
+
+            container = Substitute.For<Container>();
+            container
+                .ReadItemAsync<Record>(default, default, default)
+                .ReturnsForAnyArgs(itemResponse);
+
+            container
+                .GetItemQueryIterator<Record>(default(QueryDefinition), default)
+                .ReturnsForAnyArgs(feedIterator);
+
+            container
+                .GetItemQueryIterator<Record>(default(string), default)
+                .ReturnsForAnyArgs(feedIterator);
+
+            containerProvider = Substitute.For<ICosmosContainerProvider>();
+            containerProvider
+                .GetContainer<Record>(allowBulk: true)
+                .Returns(container, null);
+            sut = new LowPriorityCosmosBulkReader<Record>(containerProvider);
+        }
+
+        [Fact]
+        public void Implements_Interface()
+            => sut.Should().BeAssignableTo<ILowPriorityCosmosBulkReader<Record>>();
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAsync_Uses_The_Right_Container(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            await sut.ReadAsync(documentId, partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>(allowBulk: true);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAsync_Reads_Item_In_Container(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            await sut.ReadAsync(documentId, partitionKey, cancellationToken);
+
+            _ = container
+                .Received(1)
+                .ReadItemAsync<Record>(
+                    documentId,
+                    new PartitionKey(partitionKey),
+                    Arg.Is<ItemRequestOptions>(c => c.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAsync_Returns_Item_Read_From_Container(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            var result = await sut.ReadAsync(documentId, partitionKey, cancellationToken);
+            result
+                .Should()
+                .Be(itemResponse.Resource);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void ReadAsync_Throws_Expection_When_Record_IsNot_Found(
+            CosmosException exception,
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            container
+                .ReadItemAsync<Record>(default, default, default, default)
+                .ThrowsForAnyArgs(exception);
+
+            FluentActions
+                .Awaiting(() => sut.ReadAsync(documentId, partitionKey, cancellationToken))
+                .Should()
+                .ThrowAsync<CosmosException>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task FindAsync_Uses_The_Right_Container(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            await sut.FindAsync(documentId, partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>(allowBulk: true);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task FindAsync_Return_Default_When_Record_IsNot_Found(
+            CosmosException exception,
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            container
+                .ReadItemAsync<Record>(default, default, default, default)
+                .ThrowsForAnyArgs(exception);
+
+            var response = await sut.FindAsync(documentId, partitionKey, cancellationToken);
+
+            response
+                .Should()
+                .BeNull();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task FindAsync_Returns_Record_When_Successful(
+            string partitionKey,
+            string documentId,
+            CancellationToken cancellationToken)
+        {
+            var result = await sut.FindAsync(documentId, partitionKey, cancellationToken);
+            result
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void ReadAllAsync_Uses_The_Right_Container(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.ReadAllAsync(partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>(allowBulk: true);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAllAsync_Returns_Empty_No_More_Result(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut
+                .ReadAllAsync(partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAllAsync_Returns_Empty_When_Query_Matches_Non(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut
+                .ReadAllAsync(partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAllAsync_Returns_All_Items(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut
+                .ReadAllAsync(partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void QueryAsync_Uses_The_Right_Container(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.QueryAsync(query, partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>(allowBulk: true);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut.QueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Returns_Empty_When_Query_Matches_Non(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut.QueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut.QueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task Should_Have_ETag_From_ItemResponse(
+            string etag,
+            string partitionKey,
+            string documentId,
+            CancellationToken cancellationToken)
+        {
+            itemResponse
+                .ETag
+                .Returns(etag);
+            itemResponse
+                .Resource
+                .Returns(record);
+
+            var result = await sut.FindAsync(documentId, partitionKey, cancellationToken);
+
+            var resource = result as ICosmosResource;
+            resource
+                .Should()
+                .NotBeNull();
+
+            resource
+                .ETag
+                .Should()
+                .NotBeNullOrWhiteSpace();
+
+            resource
+                .ETag
+                .Should()
+                .Be(etag);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Multiple_Operations_Uses_Same_Container(
+            QueryDefinition query,
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.ReadAsync(documentId, partitionKey, cancellationToken);
+            _ = sut.ReadAsync(documentId, partitionKey, cancellationToken);
+            _ = sut.FindAsync(documentId, partitionKey, cancellationToken);
+            _ = sut.FindAsync(documentId, partitionKey, cancellationToken);
+            _ = sut.QueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+            _ = sut.QueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            container
+                .ReceivedCalls()
+                .Should()
+                .HaveCount(6);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void QueryAsync_With_Custom_Result_Uses_The_Right_Container(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.QueryAsync<Record>(query, partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>(allowBulk: true);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_With_Custom_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut.QueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_With_Custom_Returns_Empty_When_Query_Matches_Non(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut.QueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_With_Custom_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut.QueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionQueryAsync_Uses_The_Right_Container(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.CrossPartitionQueryAsync(query, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>(allowBulk: true);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionQueryAsync_Does_Not_Specify_QueryRequestOptions(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.CrossPartitionQueryAsync(query, cancellationToken).ToArrayAsync(cancellationToken);
+
+            container
+                .Received(1)
+                .GetItemQueryIterator<Record>(query, requestOptions: null);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionQueryAsync_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut.CrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionQueryAsync_Returns_Empty_When_Query_Matches_Non(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut.CrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionQueryAsync_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut.CrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionPagedQueryAsync_Uses_The_Right_Container(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.CrossPartitionPagedQueryAsync(
+                query,
+                pageSize,
+                continuationToken,
+                cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>(allowBulk: true);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionPagedQueryAsync_Gets_ItemQueryIterator(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.CrossPartitionPagedQueryAsync(
+                query,
+                pageSize,
+                continuationToken,
+                cancellationToken);
+
+            container
+                .Received(1)
+                .GetItemQueryIterator<Record>(
+                    query,
+                    continuationToken,
+                    requestOptions: Arg.Is<QueryRequestOptions>(o
+                        => o.PartitionKey == null
+                        && o.MaxItemCount == pageSize));
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionPagedQueryAsync_Returns_Empty_When_No_More_Result(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut
+                .CrossPartitionPagedQueryAsync(
+                    query,
+                    pageSize,
+                    continuationToken,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEmpty();
+            response.ContinuationToken
+                .Should()
+                .BeNull();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionPagedQueryAsync_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            List<Record> records,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true);
+            feedResponse
+                .ContinuationToken
+                .Returns(continuationToken);
+            feedResponse
+                .GetEnumerator()
+                .Returns(records.GetEnumerator());
+
+            var response = await sut
+                .CrossPartitionPagedQueryAsync(
+                    query,
+                    pageSize,
+                    null,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEquivalentTo(records);
+
+            response.ContinuationToken
+                .Should()
+                .Be(continuationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionPagedQueryAsync_With_Custom_Uses_The_Right_Container(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.CrossPartitionPagedQueryAsync<Record>(
+                query,
+                pageSize,
+                continuationToken,
+                cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>(allowBulk: true);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionPagedQueryAsync_With_Custom_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut
+                .CrossPartitionPagedQueryAsync<Record>(
+                    query,
+                    pageSize,
+                    continuationToken,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEmpty();
+            response.ContinuationToken
+                .Should()
+                .BeNull();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionPagedQueryAsync_With_Custom_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            List<Record> records,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true);
+            feedResponse
+                .ContinuationToken
+                .Returns(continuationToken);
+            feedResponse
+                .GetEnumerator()
+                .Returns(records.GetEnumerator());
+
+            var response = await sut
+                .CrossPartitionPagedQueryAsync<Record>(
+                    query,
+                    pageSize,
+                    null,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEquivalentTo(records);
+
+            response.ContinuationToken
+                .Should()
+                .Be(continuationToken);
+        }
+    }
+}
+#endif

--- a/test/Atc.Cosmos.Tests/LowPriorityCosmosReaderBatchTests.cs
+++ b/test/Atc.Cosmos.Tests/LowPriorityCosmosReaderBatchTests.cs
@@ -1,0 +1,475 @@
+#if PREVIEW
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Atc.Cosmos.Internal;
+using Atc.Test;
+using AutoFixture;
+using Dasync.Collections;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using NSubstitute;
+using Xunit;
+
+namespace Atc.Cosmos.Tests
+{
+    public class LowPriorityCosmosReaderBatchTests
+    {
+        private readonly CosmosOptions options;
+        private readonly ItemResponse<Record> itemResponse;
+        private readonly FeedIterator<Record> feedIterator;
+        private readonly FeedResponse<Record> feedResponse;
+        private readonly Record record;
+        private readonly Container container;
+        private readonly ICosmosContainerProvider containerProvider;
+        private readonly LowPriorityCosmosReader<Record> sut;
+
+        public LowPriorityCosmosReaderBatchTests()
+        {
+            var fixture = FixtureFactory.Create();
+            options = fixture.Create<CosmosOptions>();
+            record = fixture.Create<Record>();
+            itemResponse = Substitute.For<ItemResponse<Record>>();
+            itemResponse
+                .Resource
+                .Returns(record);
+
+            feedResponse = Substitute.For<FeedResponse<Record>>();
+            feedIterator = Substitute.For<FeedIterator<Record>>();
+            feedIterator
+                .ReadNextAsync(default)
+                .ReturnsForAnyArgs(feedResponse);
+
+            container = Substitute.For<Container>();
+            container
+                .ReadItemAsync<Record>(default, default, default)
+                .ReturnsForAnyArgs(itemResponse);
+
+            container
+                .GetItemQueryIterator<Record>(default(QueryDefinition), default)
+                .ReturnsForAnyArgs(feedIterator);
+
+            container
+                .GetItemQueryIterator<Record>(default(string), default)
+                .ReturnsForAnyArgs(feedIterator);
+
+            containerProvider = Substitute.For<ICosmosContainerProvider>();
+            containerProvider
+                .GetContainer<Record>()
+                .Returns(container, null);
+
+            sut = new LowPriorityCosmosReader<Record>(containerProvider);
+        }
+
+        [Fact]
+        public void Implements_Interface()
+            => sut.Should().BeAssignableTo<ILowPriorityCosmosReader<Record>>();
+
+        [Theory, AutoNSubstituteData]
+        public void ReadAllAsync_Uses_The_Right_Container(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.BatchReadAllAsync(partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAllAsync_Returns_Empty_No_More_Result(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut
+                .BatchReadAllAsync(partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAllAsync_Returns_Empty_When_Query_Matches_Non(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut
+                .BatchReadAllAsync(partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .First()
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAllAsync_Returns_All_Items(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut
+                .BatchReadAllAsync(partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .First()
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void QueryAsync_Uses_The_Right_Container(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.BatchQueryAsync(query, partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut.BatchQueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Returns_Empty_When_Query_Matches_Non(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut.BatchQueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .First()
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut.BatchQueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .First()
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Multiple_Operations_Uses_Same_Container(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.BatchReadAllAsync(partitionKey, cancellationToken).ToArrayAsync(cancellationToken);
+            _ = sut.BatchQueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+            _ = sut.BatchCrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+
+            container
+                .ReceivedCalls()
+                .Should()
+                .HaveCount(3);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void QueryAsync_With_Custom_Result_Uses_The_Right_Container(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.BatchQueryAsync<Record>(query, partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_With_Custom_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut.BatchQueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_With_Custom_Returns_Empty_When_Query_Matches_Non(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut.BatchQueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .First()
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_With_Custom_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut.BatchQueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .First()
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionQueryAsync_Uses_The_Right_Container(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.BatchCrossPartitionQueryAsync(query, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionQueryAsync_Uses_QueryRequestOptions_With_PriorityLevel_Low(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.BatchCrossPartitionQueryAsync(query, cancellationToken).ToArrayAsync(cancellationToken);
+
+            container
+                .Received(1)
+                .GetItemQueryIterator<Record>(
+                    query,
+                    requestOptions: Arg.Is<QueryRequestOptions>(
+                        c => c.PriorityLevel == PriorityLevel.Low));
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionQueryAsync_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut.BatchCrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionQueryAsync_Returns_Empty_When_Query_Matches_Non(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut.BatchCrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .First()
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionQueryAsync_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut.BatchCrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .First()
+                .Should()
+                .Be(record);
+        }
+    }
+}
+#endif

--- a/test/Atc.Cosmos.Tests/LowPriorityCosmosReaderTests.cs
+++ b/test/Atc.Cosmos.Tests/LowPriorityCosmosReaderTests.cs
@@ -1,0 +1,1035 @@
+#if PREVIEW
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Atc.Cosmos.Internal;
+using Atc.Test;
+using AutoFixture;
+using Dasync.Collections;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Atc.Cosmos.Tests
+{
+    public class LowPriorityCosmosReaderTests
+    {
+        private readonly CosmosOptions options;
+        private readonly ItemResponse<Record> itemResponse;
+        private readonly FeedIterator<Record> feedIterator;
+        private readonly FeedResponse<Record> feedResponse;
+        private readonly Record record;
+        private readonly Container container;
+        private readonly ICosmosContainerProvider containerProvider;
+        private readonly LowPriorityCosmosReader<Record> sut;
+
+        public LowPriorityCosmosReaderTests()
+        {
+            var fixture = FixtureFactory.Create();
+            options = fixture.Create<CosmosOptions>();
+            record = fixture.Create<Record>();
+            itemResponse = Substitute.For<ItemResponse<Record>>();
+            itemResponse
+                .Resource
+                .Returns(record);
+
+            feedResponse = Substitute.For<FeedResponse<Record>>();
+            feedIterator = Substitute.For<FeedIterator<Record>>();
+            feedIterator
+                .ReadNextAsync(default)
+                .ReturnsForAnyArgs(feedResponse);
+
+            container = Substitute.For<Container>();
+            container
+                .ReadItemAsync<Record>(default, default, default)
+                .ReturnsForAnyArgs(itemResponse);
+
+            container
+                .GetItemQueryIterator<Record>(default(QueryDefinition), default)
+                .ReturnsForAnyArgs(feedIterator);
+
+            container
+                .GetItemQueryIterator<Record>(default(string), default)
+                .ReturnsForAnyArgs(feedIterator);
+
+            containerProvider = Substitute.For<ICosmosContainerProvider>();
+            containerProvider
+                .GetContainer<Record>()
+                .Returns(container, null);
+            containerProvider
+                .GetCosmosOptions<Record>()
+                .Returns(options);
+
+            sut = new LowPriorityCosmosReader<Record>(containerProvider);
+        }
+
+        [Fact]
+        public void Implements_Interface()
+            => sut.Should().BeAssignableTo<ILowPriorityCosmosReader<Record>>();
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAsync_Uses_The_Right_Container(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            await sut.ReadAsync(documentId, partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAsync_Reads_Item_In_Container_Using_PriorityLevel_Low(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            await sut.ReadAsync(documentId, partitionKey, cancellationToken);
+
+            _ = container
+                .Received(1)
+                .ReadItemAsync<Record>(
+                    documentId,
+                    new PartitionKey(partitionKey),
+                    Arg.Is<ItemRequestOptions>(c => c.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAsync_Returns_Item_Read_From_Container(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            var result = await sut.ReadAsync(documentId, partitionKey, cancellationToken);
+            result
+                .Should()
+                .Be(itemResponse.Resource);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void ReadAsync_Throws_Expection_When_Record_IsNot_Found(
+            CosmosException exception,
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            container
+                .ReadItemAsync<Record>(default, default, default, default)
+                .ThrowsForAnyArgs(exception);
+
+            FluentActions
+                .Awaiting(() => sut.ReadAsync(documentId, partitionKey, cancellationToken))
+                .Should()
+                .ThrowAsync<CosmosException>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task FindAsync_Uses_The_Right_Container(
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            await sut.FindAsync(documentId, partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task FindAsync_Return_Default_When_Record_IsNot_Found(
+            CosmosException exception,
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            container
+                .ReadItemAsync<Record>(default, default, default, default)
+                .ThrowsForAnyArgs(exception);
+
+            var response = await sut.FindAsync(documentId, partitionKey, cancellationToken);
+
+            response
+                .Should()
+                .BeNull();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task FindAsync_Returns_Record_When_Successful(
+            string partitionKey,
+            string documentId,
+            CancellationToken cancellationToken)
+        {
+            var result = await sut.FindAsync(documentId, partitionKey, cancellationToken);
+            result
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void ReadAllAsync_Uses_The_Right_Container(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.ReadAllAsync(partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAllAsync_Returns_Empty_No_More_Result(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut
+                .ReadAllAsync(partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAllAsync_Returns_Empty_When_Query_Matches_Non(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut
+                .ReadAllAsync(partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReadAllAsync_Returns_All_Items(
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut
+                .ReadAllAsync(partitionKey, cancellationToken)
+                .ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void QueryAsync_Uses_The_Right_Container(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.QueryAsync(query, partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut.QueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Returns_Empty_When_Query_Matches_Non(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut.QueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut.QueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task Should_Have_ETag_From_ItemResponse(
+            string etag,
+            string partitionKey,
+            string documentId,
+            CancellationToken cancellationToken)
+        {
+            itemResponse
+                .ETag
+                .Returns(etag);
+            itemResponse
+                .Resource
+                .Returns(record);
+
+            var result = await sut.FindAsync(documentId, partitionKey, cancellationToken);
+
+            var resource = result as ICosmosResource;
+            resource
+                .Should()
+                .NotBeNull();
+
+            resource
+                .ETag
+                .Should()
+                .NotBeNullOrWhiteSpace();
+
+            resource
+                .ETag
+                .Should()
+                .Be(etag);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Multiple_Operations_Uses_Same_Container(
+            QueryDefinition query,
+            string documentId,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.ReadAsync(documentId, partitionKey, cancellationToken);
+            _ = sut.ReadAsync(documentId, partitionKey, cancellationToken);
+            _ = sut.FindAsync(documentId, partitionKey, cancellationToken);
+            _ = sut.FindAsync(documentId, partitionKey, cancellationToken);
+            _ = sut.QueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+            _ = sut.QueryAsync(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            container
+                .ReceivedCalls()
+                .Should()
+                .HaveCount(6);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void QueryAsync_With_Custom_Result_Uses_The_Right_Container(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.QueryAsync<Record>(query, partitionKey, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_With_Custom_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut.QueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_With_Custom_Returns_Empty_When_Query_Matches_Non(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut.QueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task QueryAsync_With_Custom_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            string partitionKey,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut.QueryAsync<Record>(query, partitionKey, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void PagedQueryAsync_Uses_The_Right_Container(
+            QueryDefinition query,
+            string partitionKey,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.PagedQueryAsync(
+                query,
+                partitionKey,
+                pageSize,
+                continuationToken,
+                cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void PagedQueryAsync_Gets_ItemQueryIterator(
+            QueryDefinition query,
+            string partitionKey,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.PagedQueryAsync(
+                query,
+                partitionKey,
+                pageSize,
+                continuationToken,
+                cancellationToken);
+
+            container
+                .Received(1)
+                .GetItemQueryIterator<Record>(
+                    query,
+                    continuationToken,
+                    requestOptions: Arg.Is<QueryRequestOptions>(o
+                        => o.PartitionKey == new PartitionKey(partitionKey)
+                        && o.MaxItemCount == pageSize
+                        && o.ResponseContinuationTokenLimitInKb == options.ContinuationTokenLimitInKb));
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task PagedQueryAsync_Returns_Empty_When_No_More_Result(
+            QueryDefinition query,
+            string partitionKey,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut
+                .PagedQueryAsync(
+                    query,
+                    partitionKey,
+                    pageSize,
+                    continuationToken,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEmpty();
+            response.ContinuationToken
+                .Should()
+                .BeNull();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task PagedQueryAsync_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            string partitionKey,
+            int pageSize,
+            string continuationToken,
+            List<Record> records,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true);
+            feedResponse
+                .ContinuationToken
+                .Returns(continuationToken);
+            feedResponse
+                .GetEnumerator()
+                .Returns(records.GetEnumerator());
+
+            var response = await sut
+                .PagedQueryAsync(
+                    query,
+                    partitionKey,
+                    pageSize,
+                    null,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEquivalentTo(records);
+
+            response.ContinuationToken
+                .Should()
+                .Be(continuationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void PagedQueryAsync_With_Custom_Uses_The_Right_Container(
+            QueryDefinition query,
+            string partitionKey,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.PagedQueryAsync<Record>(
+                query,
+                partitionKey,
+                pageSize,
+                continuationToken,
+                cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task PagedQueryAsync_With_Custom_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            string partitionKey,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut
+                .PagedQueryAsync<Record>(
+                    query,
+                    partitionKey,
+                    pageSize,
+                    continuationToken,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEmpty();
+            response.ContinuationToken
+                .Should()
+                .BeNull();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task PagedQueryAsync_With_Custom_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            string partitionKey,
+            int pageSize,
+            string continuationToken,
+            List<Record> records,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true);
+            feedResponse
+                .ContinuationToken
+                .Returns(continuationToken);
+            feedResponse
+                .GetEnumerator()
+                .Returns(records.GetEnumerator());
+
+            var response = await sut
+                .PagedQueryAsync<Record>(
+                    query,
+                    partitionKey,
+                    pageSize,
+                    null,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEquivalentTo(records);
+
+            response.ContinuationToken
+                .Should()
+                .Be(continuationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionQueryAsync_Uses_The_Right_Container(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.CrossPartitionQueryAsync(query, cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionQueryAsync_Does_Not_Specify_QueryRequestOptions(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.CrossPartitionQueryAsync(query, cancellationToken).ToArrayAsync(cancellationToken);
+
+            container
+                .Received(1)
+                .GetItemQueryIterator<Record>(query, requestOptions: null);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionQueryAsync_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut.CrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionQueryAsync_Returns_Empty_When_Query_Matches_Non(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(true, false);
+
+            var response = await sut.CrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .BeEmpty();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionQueryAsync_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true, false);
+
+            feedResponse
+                .GetEnumerator()
+                .Returns(new List<Record> { record }.GetEnumerator());
+
+            var response = await sut.CrossPartitionQueryAsync(query, cancellationToken).ToListAsync(cancellationToken);
+
+            _ = feedIterator
+                .Received(2)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response
+                .Should()
+                .NotBeEmpty();
+
+            response[0]
+                .Should()
+                .Be(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionPagedQueryAsync_Uses_The_Right_Container(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.CrossPartitionPagedQueryAsync(
+                query,
+                pageSize,
+                continuationToken,
+                cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionPagedQueryAsync_Gets_ItemQueryIterator(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.CrossPartitionPagedQueryAsync(
+                query,
+                pageSize,
+                continuationToken,
+                cancellationToken);
+
+            container
+                .Received(1)
+                .GetItemQueryIterator<Record>(
+                    query,
+                    continuationToken,
+                    requestOptions: Arg.Is<QueryRequestOptions>(o
+                        => o.PartitionKey == null
+                        && o.MaxItemCount == pageSize
+                        && o.ResponseContinuationTokenLimitInKb == options.ContinuationTokenLimitInKb));
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionPagedQueryAsync_Returns_Empty_When_No_More_Result(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut
+                .CrossPartitionPagedQueryAsync(
+                    query,
+                    pageSize,
+                    continuationToken,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEmpty();
+            response.ContinuationToken
+                .Should()
+                .BeNull();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionPagedQueryAsync_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            List<Record> records,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true);
+            feedResponse
+                .ContinuationToken
+                .Returns(continuationToken);
+            feedResponse
+                .GetEnumerator()
+                .Returns(records.GetEnumerator());
+
+            var response = await sut
+                .CrossPartitionPagedQueryAsync(
+                    query,
+                    pageSize,
+                    null,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEquivalentTo(records);
+
+            response.ContinuationToken
+                .Should()
+                .Be(continuationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void CrossPartitionPagedQueryAsync_With_Custom_Uses_The_Right_Container(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            _ = sut.CrossPartitionPagedQueryAsync<Record>(
+                query,
+                pageSize,
+                continuationToken,
+                cancellationToken);
+
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionPagedQueryAsync_With_Custom_Returns_Empty_No_More_Result(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            CancellationToken cancellationToken)
+        {
+            feedIterator.HasMoreResults.Returns(false);
+
+            var response = await sut
+                .CrossPartitionPagedQueryAsync<Record>(
+                    query,
+                    pageSize,
+                    continuationToken,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(0)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEmpty();
+            response.ContinuationToken
+                .Should()
+                .BeNull();
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CrossPartitionPagedQueryAsync_With_Custom_Returns_Items_When_Query_Matches(
+            QueryDefinition query,
+            int pageSize,
+            string continuationToken,
+            List<Record> records,
+            CancellationToken cancellationToken)
+        {
+            feedIterator
+                .HasMoreResults
+                .Returns(true);
+            feedResponse
+                .ContinuationToken
+                .Returns(continuationToken);
+            feedResponse
+                .GetEnumerator()
+                .Returns(records.GetEnumerator());
+
+            var response = await sut
+                .CrossPartitionPagedQueryAsync<Record>(
+                    query,
+                    pageSize,
+                    null,
+                    cancellationToken);
+
+            _ = feedIterator
+                .Received(1)
+                .HasMoreResults;
+
+            _ = feedIterator
+                .Received(1)
+                .ReadNextAsync(default);
+
+            response.Items
+                .Should()
+                .BeEquivalentTo(records);
+
+            response.ContinuationToken
+                .Should()
+                .Be(continuationToken);
+        }
+    }
+}
+#endif

--- a/test/Atc.Cosmos.Tests/LowPriorityCosmosWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/LowPriorityCosmosWriterTests.cs
@@ -1,0 +1,490 @@
+#if PREVIEW
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Atc.Cosmos.Internal;
+using Atc.Cosmos.Serialization;
+using Atc.Test;
+using AutoFixture;
+using AutoFixture.AutoNSubstitute;
+using FluentAssertions;
+using Microsoft.Azure.Cosmos;
+using NSubstitute;
+using Xunit;
+
+namespace Atc.Cosmos.Tests
+{
+    public class LowPriorityCosmosWriterTests
+    {
+        private readonly Record record;
+        private readonly Container container;
+        private readonly ICosmosContainerProvider containerProvider;
+        private readonly ILowPriorityCosmosReader<Record> reader;
+        private readonly IJsonCosmosSerializer serializer;
+        private readonly LowPriorityCosmosWriter<Record> sut;
+
+        public LowPriorityCosmosWriterTests()
+        {
+            record = new Fixture().Create<Record>();
+
+            container = Substitute.For<Container>();
+
+            containerProvider = Substitute.For<ICosmosContainerProvider>();
+            containerProvider
+                .GetContainer<Record>()
+                .ReturnsForAnyArgs(container, null);
+
+            var response = Substitute.For<ItemResponse<object>>();
+            response.Resource.Returns(new Fixture().Create<string>());
+            container
+                .CreateItemAsync<object>(default, default, default, default)
+                .ReturnsForAnyArgs(response);
+            container
+                .ReplaceItemAsync<object>(default, default, default, default, default)
+                .ReturnsForAnyArgs(response);
+            container
+                .UpsertItemAsync<object>(default, default, default, default)
+                .ReturnsForAnyArgs(response);
+            container
+                .PatchItemAsync<object>(default, default, default, default)
+                .ReturnsForAnyArgs(response);
+
+            reader = Substitute.For<ILowPriorityCosmosReader<Record>>();
+            reader
+                .ReadAsync(default, default, default)
+                .ReturnsForAnyArgs(record);
+
+            serializer = Substitute.For<IJsonCosmosSerializer>();
+            serializer
+                .FromString<Record>(default)
+                .ReturnsForAnyArgs(new Fixture().Create<Record>());
+
+            sut = new LowPriorityCosmosWriter<Record>(containerProvider, reader, serializer);
+        }
+
+        [Fact]
+        public void Implements_Interface()
+            => sut.Should().BeAssignableTo<ILowPriorityCosmosWriter<Record>>();
+
+        [Theory, AutoNSubstituteData]
+        public async Task WriteAsync_Uses_The_Right_Container(
+            CancellationToken cancellationToken)
+        {
+            await sut.WriteAsync(record, cancellationToken);
+            containerProvider
+                .Received(1)
+                .GetContainer<Record>(
+                    allowBulk: false);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task WriteAsync_UpsertItem_In_Container(
+            CancellationToken cancellationToken)
+        {
+            containerProvider
+                .GetContainer<Record>()
+                .ReturnsForAnyArgs(container);
+
+            await sut.WriteAsync(record, cancellationToken);
+            await container
+                .Received(1)
+                .UpsertItemAsync<object>(
+                    record,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(c => c.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task WriteWithNoResponseAsync_UpsertItem_In_Container(
+            CancellationToken cancellationToken)
+        {
+            containerProvider
+                .GetContainer<Record>()
+                .ReturnsForAnyArgs(container);
+
+            await sut.WriteWithNoResponseAsync(record, cancellationToken);
+            await container
+                .Received(1)
+                .UpsertItemAsync<object>(
+                    record,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(
+                        p => p.EnableContentResponseOnWrite == false && p.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CreateAsync_Calls_CreateItem_On_Container(
+           CancellationToken cancellationToken)
+        {
+            await sut.CreateAsync(record, cancellationToken);
+            _ = container
+                .Received(1)
+                .CreateItemAsync<object>(
+                    record,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task CreateWithNoResponseAsync_Calls_CreateItem_On_Container(
+           CancellationToken cancellationToken)
+        {
+            await sut.CreateWithNoResponseAsync(record, cancellationToken);
+            _ = container
+                .Received(1)
+                .CreateItemAsync<object>(
+                    record,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(p => p.EnableContentResponseOnWrite == false && p.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReplaceAsync_Calls_ReplaceItemAsync_On_Container(
+           CancellationToken cancellationToken)
+        {
+            await sut.ReplaceAsync(record, cancellationToken);
+            _ = container
+                .Received(1)
+                .ReplaceItemAsync<object>(
+                    record,
+                    record.Id,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(
+                        o => o.IfMatchEtag == record.ETag && o.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task ReplaceWithNoResponseAsync_Calls_ReplaceItemAsync_On_Container(
+           CancellationToken cancellationToken)
+        {
+            await sut.ReplaceWithNoResponseAsync(record, cancellationToken);
+            _ = container
+                .Received(1)
+                .ReplaceItemAsync<object>(
+                    record,
+                    record.Id,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.IfMatchEtag == record.ETag
+                                                 && o.EnableContentResponseOnWrite == false
+                                                 && o.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public void Multiple_Operations_Uses_Same_Container(
+            CancellationToken cancellationToken)
+        {
+            _ = sut.WriteAsync(record, cancellationToken);
+            _ = sut.WriteAsync(record, cancellationToken);
+            _ = sut.CreateAsync(record, cancellationToken);
+            _ = sut.CreateAsync(record, cancellationToken);
+            _ = sut.ReplaceAsync(record, cancellationToken);
+            _ = sut.ReplaceAsync(record, cancellationToken);
+
+            container
+                .ReceivedCalls()
+                .Should()
+                .HaveCount(6);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task DeleteAsync_Calls_DeleteItemAsync_On_Container(
+           CancellationToken cancellationToken)
+        {
+            await sut.DeleteAsync(record.Id, record.Pk, cancellationToken);
+            _ = container
+                .Received(1)
+                .DeleteItemAsync<object>(
+                    record.Id,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken: cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task Should_Return_True_When_Trying_To_Delete_Existing_Resource(
+           CancellationToken cancellationToken)
+        {
+            var deleted = await sut.TryDeleteAsync(
+                record.Id,
+                record.Pk,
+                cancellationToken);
+
+            deleted
+                .Should()
+                .BeTrue();
+
+            _ = container
+                .Received(1)
+                .DeleteItemAsync<object>(
+                    record.Id,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken: cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task Should_Return_False_When_Trying_To_Delete_NonExisting_Resource(
+           CancellationToken cancellationToken)
+        {
+            container
+                .DeleteItemAsync<object>(default, default, default, default)
+                .ReturnsForAnyArgs<ItemResponse<object>>(
+                    r => throw new CosmosException("fake", HttpStatusCode.NotFound, 0, "1", 1));
+
+            var deleted = await sut.TryDeleteAsync(
+                record.Id,
+                record.Pk,
+                cancellationToken);
+
+            deleted
+                .Should()
+                .BeFalse();
+
+            _ = container
+                .Received(1)
+                .DeleteItemAsync<object>(
+                    record.Id,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken: cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateAsync_Reads_The_Resource(
+            string documentId,
+            string partitionKey,
+            Action<Record> updateDocument,
+            int retries,
+            CancellationToken cancellationToken)
+        {
+            await sut.UpdateAsync(
+                documentId,
+                partitionKey,
+                updateDocument,
+                retries,
+                cancellationToken);
+
+            _ = reader
+                .Received(1)
+                .ReadAsync(
+                    documentId,
+                    partitionKey,
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateAsync_Calls_UpdateDocument_With_Read_Resource(
+            string documentId,
+            string partitionKey,
+            [Substitute] Action<Record> updateDocument,
+            int retries,
+            CancellationToken cancellationToken)
+        {
+            await sut.UpdateAsync(
+                documentId,
+                partitionKey,
+                updateDocument,
+                retries,
+                cancellationToken);
+
+            updateDocument
+                .Received(1)
+                .Invoke(record);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateAsync_Calls_ReplaceItem_With_Updated_Resource(
+            string documentId,
+            string partitionKey,
+            [Substitute] Action<Record> updateDocument,
+            int retries,
+            CancellationToken cancellationToken)
+        {
+            await sut.UpdateAsync(
+                documentId,
+                partitionKey,
+                updateDocument,
+                retries,
+                cancellationToken);
+
+            _ = container
+                .Received(1)
+                .ReplaceItemAsync<object>(
+                    record,
+                    record.Id,
+                    new PartitionKey(record.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.IfMatchEtag == record.ETag && o.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateOrCreateAsync_Finds_The_Resource(
+           Action<Record> updateDocument,
+           int retries,
+           Record defaultDocument,
+           CancellationToken cancellationToken)
+        {
+            await sut.UpdateOrCreateAsync(
+                () => defaultDocument,
+                updateDocument,
+                retries,
+                cancellationToken);
+
+            _ = reader
+                .Received(1)
+                .FindAsync(
+                    defaultDocument.Id,
+                    defaultDocument.Pk,
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateAsync_Calls_UpdateDocument_With_Found_Resource(
+            [Substitute] Action<Record> updateDocument,
+            int retries,
+            Record defaultDocument,
+            Record foundResource,
+            CancellationToken cancellationToken)
+        {
+            reader
+                .FindAsync(default, default, default)
+                .ReturnsForAnyArgs(foundResource);
+
+            await sut.UpdateOrCreateAsync(
+                () => defaultDocument,
+                updateDocument,
+                retries,
+                cancellationToken);
+
+            updateDocument
+                .Received(1)
+                .Invoke(foundResource);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateAsync_Calls_UpdateDocument_With_Default_Document_If_Not_Found(
+            [Substitute] Action<Record> updateDocument,
+            int retries,
+            Record defaultDocument,
+            CancellationToken cancellationToken)
+        {
+            await sut.UpdateOrCreateAsync(
+                () => defaultDocument,
+                updateDocument,
+                retries,
+                cancellationToken);
+
+            updateDocument
+                .Received(1)
+                .Invoke(defaultDocument);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateOrCreateAsync_Calls_ReplaceItem_If_Resource_Has_ETag(
+            [Substitute] Action<Record> updateDocument,
+            int retries,
+            Record defaultDocument,
+            Record foundResource,
+            string etag,
+            CancellationToken cancellationToken)
+        {
+            ((ICosmosResource)foundResource).ETag = etag;
+            reader
+                .FindAsync(default, default, default)
+                .ReturnsForAnyArgs(foundResource);
+
+            await sut.UpdateOrCreateAsync(
+                () => defaultDocument,
+                updateDocument,
+                retries,
+                cancellationToken);
+
+            _ = container
+                .Received(1)
+                .ReplaceItemAsync<object>(
+                    foundResource,
+                    foundResource.Id,
+                    new PartitionKey(foundResource.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.IfMatchEtag == foundResource.ETag && o.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task UpdateOrCreateAsync_Calls_CreateItem_If_Resource_Has_No_ETag(
+            [Substitute] Action<Record> updateDocument,
+            int retries,
+            Record defaultDocument,
+            CancellationToken cancellationToken)
+        {
+            defaultDocument.ETag = null;
+            await sut.UpdateOrCreateAsync(
+                () => defaultDocument,
+                updateDocument,
+                retries,
+                cancellationToken);
+
+            _ = container
+                .Received(1)
+                .CreateItemAsync<object>(
+                    defaultDocument,
+                    new PartitionKey(defaultDocument.Pk),
+                    Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task PatchAsync_Calls_PatchItemAsync_On_Container(
+            IReadOnlyList<PatchOperation> patchOperations,
+            string filterPredicate,
+            CancellationToken cancellationToken)
+        {
+            await sut.PatchAsync(
+                record.Id,
+                record.Pk,
+                patchOperations,
+                filterPredicate,
+                cancellationToken);
+
+            _ = container
+                .Received(1)
+                .PatchItemAsync<object>(
+                    record.Id,
+                    new PartitionKey(record.Pk),
+                    patchOperations,
+                    Arg.Is<PatchItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+
+        [Theory, AutoNSubstituteData]
+        public async Task PatchWithNoResponseAsync_Calls_PatchItemAsync_On_Container(
+            IReadOnlyList<PatchOperation> patchOperations,
+            string filterPredicate,
+            CancellationToken cancellationToken)
+        {
+            await sut.PatchWithNoResponseAsync(
+                record.Id,
+                record.Pk,
+                patchOperations,
+                filterPredicate,
+                cancellationToken);
+
+            _ = container
+                .Received(1)
+                .PatchItemAsync<object>(
+                    record.Id,
+                    new PartitionKey(record.Pk),
+                    patchOperations,
+                    Arg.Is<PatchItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.Low),
+                    cancellationToken);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
The changes here adds support for using [priority-based execution](https://devblogs.microsoft.com/cosmosdb/introducing-priority-based-execution-in-azure-cosmos-db-preview/) using the preview version of the Cosmos SDK. This is implemented by updating the default readers and writers to use a high execution priority and introducing interfaces for low-priority readers and writers.

The build now produces 2 NuGet packages
- Atc.Cosmos.1.x.x.nukpg
- Atc.Cosmos.1.x.x-preview.nukpg

The `-preview` NuGet package contains a dependency to the preview version of the Cosmos SDK, and the other NuGet package depends on the stable version. The components that target the preview version of the Cosmos SDK are hidden behind a pre-compiler definition called `PREVIEW`. 

Priority-based execution currently is not enabled by default and to get started using it you need to fill out this [nomination form](https://forms.microsoft.com/Pages/ResponsePage.aspx?id=v4j5cvGGr0GRqy180BHbR_kUn4g8ufhFjXbbwUF1gXFUMUQzUzFZSVkzODRSRkxXM0RKVDNUSDBGNi4u). After submitting, a member of the CosmosDb team will reach out and enable the feature on the accounts you listed and contact you to let you know it’s ready for use.

I had to make some changes to the Github workflows and get rid of the NerdBank.GitVersioning package reference. The output NuGet packages are pretty much as the previous workflow

![image](https://github.com/atc-net/atc-cosmos/assets/710400/119232cb-5394-44ab-96a6-2424bc61e432)
