### PR TITLE
Use custom serializer for LINQ query translation

### DIFF
--- a/src/Atc.Cosmos/Internal/CosmosSerializerAdapter.cs
+++ b/src/Atc.Cosmos/Internal/CosmosSerializerAdapter.cs
@@ -1,11 +1,12 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Reflection;
 using Atc.Cosmos.Serialization;
 using Microsoft.Azure.Cosmos;
 
 namespace Atc.Cosmos.Internal
 {
-    public class CosmosSerializerAdapter : CosmosSerializer
+    public class CosmosSerializerAdapter : CosmosLinqSerializer
     {
         public CosmosSerializerAdapter(IJsonCosmosSerializer serializer)
         {
@@ -20,5 +21,8 @@ namespace Atc.Cosmos.Internal
 
         public override Stream ToStream<T>(T input)
             => Serializer.ToStream(input);
+
+        public override string SerializeMemberName(MemberInfo memberInfo)
+            => Serializer.SerializeMemberName(memberInfo);
     }
 }

--- a/src/Atc.Cosmos/Serialization/IJsonCosmosSerializer.cs
+++ b/src/Atc.Cosmos/Serialization/IJsonCosmosSerializer.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Reflection;
 
 namespace Atc.Cosmos.Serialization
 {
@@ -9,6 +10,8 @@ namespace Atc.Cosmos.Serialization
         T FromStream<T>(Stream stream);
 
         Stream ToStream<T>(T input);
+
+        string SerializeMemberName(MemberInfo memberInfo);
 
         [return: MaybeNull]
         T FromString<T>(string json);

--- a/src/Atc.Cosmos/Serialization/JsonCosmosSerializer.cs
+++ b/src/Atc.Cosmos/Serialization/JsonCosmosSerializer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Reflection;
 using System.Text.Json;
 using Microsoft.Extensions.Options;
 
@@ -72,6 +73,10 @@ namespace Atc.Cosmos.Serialization
 
             return streamPayload;
         }
+
+        public string SerializeMemberName(MemberInfo memberInfo)
+            => options.PropertyNamingPolicy?.ConvertName(memberInfo.Name) ??
+               memberInfo.Name;
 
         [return: MaybeNull]
         public T FromString<T>(string json)


### PR DESCRIPTION
Utilizes new [functionality](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4138) to provide custom serializer logic for LINQ query translation.

This means that generated queries can now adhere to things like naming policy and custom JsonConverters (e.g. for string enum conversion).