### PR TITLE
Release DeletePartitionAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,40 +249,6 @@ az cosmosdb update  --resource-group $ResourceGroup --name $AccountName --enable
 
 See [MS Learn](https://learn.microsoft.com/en-us/azure/cosmos-db/priority-based-execution) for more details.
 
-### Delete resources by partition key
-
-The preview version of the library extends the `ICosmosWriter` and `ILowPriorityCosmosWriter` with and additional method `DeletePartitionAsync` to delete all resources in a container based on a partition key. The deletion will be executed in a CosmosDB background service using a percentage of the RU's available. The effect are available immediatly as all resources in the partition will not be available through reads or queries.
-
-In order to use this new method the "Delete All Items By Partition Key" feature needs to be enabled on the CosmosDB account. 
-
-This can be done through Azure CLI:
-
-```bash
-# Delete All Items By Partition Key
-az cosmosdb update  --resource-group $ResourceGroup --name $AccountName --capabilities DeleteAllItemsByPartitionKey
-```
-
-or wih bicep:
-
-```bicep
-resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
-  name: cosmosName
-  properties: {
-    databaseAccountOfferType: 'Standard'
-    locations: location
-    capabilities: [
-      {
-        name: 'DeleteAllItemsByPartitionKey'
-      }
-    ]
-  }
-}
-```
-
-If the feature is not enabled when calling this method then a `CosmosException` will be thrown.
-
-See [MS Learn](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-delete-by-partition-key) for more details.
-
 ## Unit Testing
 The reader and writer interfaces can easily be mocked, but in some cases it is nice to have a fake version of a reader or writer to mimic the behavior of the read and write operations. For this purpose the `Atc.Cosmos.Testing` namespace contains the following fakes:
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-      "rollForward": "latestMajor",
-      "allowPrerelease": false
+    "version": "8.0.0",
+    "rollForward": "latestMinor",
+    "allowPrerelease": false
   }
 }

--- a/src/Atc.Cosmos/Atc.Cosmos.csproj
+++ b/src/Atc.Cosmos/Atc.Cosmos.csproj
@@ -12,9 +12,10 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.45.0-preview.0" Condition="$(IsPreview)" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.44.1" Condition="!$(IsPreview)" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.47.0-preview.0" Condition="$(IsPreview)" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.0" Condition="!$(IsPreview)" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">

--- a/src/Atc.Cosmos/ICosmosWriter.cs
+++ b/src/Atc.Cosmos/ICosmosWriter.cs
@@ -149,7 +149,6 @@ namespace Atc.Cosmos
             string documentId,
             string partitionKey,
             CancellationToken cancellationToken = default);
-#if PREVIEW
 
         /// <summary>
         /// Preview Feature DeleteAllItemsByPartitionKey.<br/>
@@ -168,7 +167,6 @@ namespace Atc.Cosmos
         public Task DeletePartitionAsync(
             string partitionKey,
             CancellationToken cancellationToken = default);
-#endif
 
         /// <summary>
         /// Updates a <typeparamref name="T"/> resource that is read from the configured

--- a/src/Atc.Cosmos/Internal/CosmosWriter.cs
+++ b/src/Atc.Cosmos/Internal/CosmosWriter.cs
@@ -175,7 +175,6 @@ namespace Atc.Cosmos.Internal
 
             return true;
         }
-#if PREVIEW
 
         public Task DeletePartitionAsync(
             string partitionKey,
@@ -185,11 +184,12 @@ namespace Atc.Cosmos.Internal
                     new PartitionKey(partitionKey),
                     new ItemRequestOptions
                     {
+#if PREVIEW
                         PriorityLevel = PriorityLevel,
+#endif
                     },
                     cancellationToken: cancellationToken)
                 .ProcessResponseMessage();
-#endif
 
         public Task<T> UpdateAsync(
             string documentId,

--- a/src/Atc.Cosmos/Testing/FakeCosmos.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmos.cs
@@ -481,7 +481,6 @@ namespace Atc.Cosmos.Testing
                     documentId,
                     partitionKey,
                     cancellationToken);
-#if PREVIEW
 
         Task ICosmosWriter<T>.DeletePartitionAsync(
             string partitionKey,
@@ -490,7 +489,6 @@ namespace Atc.Cosmos.Testing
                 .DeletePartitionAsync(
                     partitionKey,
                     cancellationToken);
-#endif
 
         Task<T> ICosmosWriter<T>.UpdateAsync(
             string documentId,

--- a/src/Atc.Cosmos/Testing/FakeCosmosWriter.cs
+++ b/src/Atc.Cosmos/Testing/FakeCosmosWriter.cs
@@ -153,7 +153,6 @@ namespace Atc.Cosmos.Testing
 
             return true;
         }
-#if PREVIEW
 
         public virtual Task DeletePartitionAsync(
             string partitionKey,
@@ -164,7 +163,6 @@ namespace Atc.Cosmos.Testing
 
             return Task.CompletedTask;
         }
-#endif
 
         public virtual Task<T> UpdateAsync(
             string documentId,

--- a/test/Atc.Cosmos.Tests/CosmosWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosWriterTests.cs
@@ -296,7 +296,6 @@ namespace Atc.Cosmos.Tests
 #endif
                     cancellationToken: cancellationToken);
         }
-#if PREVIEW
 
         [Theory, AutoNSubstituteData]
         public async Task DeletePartitionAsync_Calls_DeleteAllItemsByPartitionKeyStreamAsync_On_Container(
@@ -323,7 +322,6 @@ namespace Atc.Cosmos.Tests
             Func<Task> act = () => sut.DeletePartitionAsync(record.Pk, cancellationToken);
             return act.Should().ThrowAsync<CosmosException>();
         }
-#endif
 
         [Theory, AutoNSubstituteData]
         public async Task UpdateAsync_Reads_The_Resource(

--- a/test/Atc.Cosmos.Tests/CosmosWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/CosmosWriterTests.cs
@@ -306,7 +306,11 @@ namespace Atc.Cosmos.Tests
                 .Received(1)
                 .DeleteAllItemsByPartitionKeyStreamAsync(
                     new PartitionKey(record.Pk),
+#if PREVIEW
                     Arg.Is<ItemRequestOptions>(o => o.PriorityLevel == PriorityLevel.High),
+#else
+                    Arg.Any<ItemRequestOptions>(),
+#endif
                     cancellationToken: cancellationToken);
         }
 

--- a/test/Atc.Cosmos.Tests/Testing/FakeCosmosWriterTests.cs
+++ b/test/Atc.Cosmos.Tests/Testing/FakeCosmosWriterTests.cs
@@ -211,7 +211,6 @@ namespace Atc.Cosmos.Tests.Testing
                 .Should()
                 .NotContain(existingDocument);
         }
-#if PREVIEW
 
         [Theory, AutoNSubstituteData]
         public async Task DeletePartitionAsyncAsync_Should_Delete_Existing_Documents(
@@ -249,7 +248,6 @@ namespace Atc.Cosmos.Tests.Testing
                 .And
                 .Contain(existingDocument3);
         }
-#endif
 
         [Theory, AutoNSubstituteData]
         public void UpdateAsync_Should_Throw_If_Document_Does_Not_Exists(


### PR DESCRIPTION
As part of Cosmos SDK version 3.45.0 the `DeleteAllItemsByPartitionKeyStreamAsync` is globally available which means that the `ICosmosWriter.DeletePartitionAsync` no longer needs to be part of the preview flag.

As part of the upgrade of the Cosmos SDK 3.46.0 introduced a breaking change where consumers needs to explicitly reference Newtonsoft.

In addition, the repo is set to target .net8 to postpone handling warnings introduces as part of .net 9